### PR TITLE
Update framework to support greater modularity to facilitate Crate version upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <version>1.1.1</version>
+    <version>1.2.0</version>
     <groupId>com.zoomdata</groupId>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>connector-server-cratedb</artifactId>
@@ -11,23 +11,23 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Copyright -->
         <inceptionYear>2012</inceptionYear>
-        <currentYear>2016</currentYear>
+        <currentYear>2017</currentYear>
         <copyrightOwner>Zoomdata, Inc.</copyrightOwner>
         <!-- Versions -->
         <connector-api.version>2.3.1</connector-api.version>
         <crate.jdbc.version>1.13.1</crate.jdbc.version>
         <query.dsl.version>4.1.4</query.dsl.version>
-        <slf4j.version>1.7.21</slf4j.version>
-        <logback.version>1.1.7</logback.version>
-        <lombok.version>1.16.10</lombok.version>
+        <slf4j.version>1.7.22</slf4j.version>
+        <logback.version>1.1.8</logback.version>
+        <lombok.version>1.16.12</lombok.version>
         <thrift.version>0.9.3</thrift.version>
         <dbcp2.version>2.1.1</dbcp2.version>
         <!-- Additional versions for core things -->
-        <spring.boot.version>1.4.0.RELEASE</spring.boot.version>
+        <spring.boot.version>1.4.3.RELEASE</spring.boot.version>
         <json.version>20160810</json.version>
         <joda.time.version>2.9.4</joda.time.version>
         <commons.lang.version>3.4</commons.lang.version>
-        <guava.version>19.0</guava.version>
+        <guava.version>20.0</guava.version>
     </properties>
 
     <repositories>

--- a/src/main/java/com/zoomdata/connector/example/common/utils/CollectionUtils.java
+++ b/src/main/java/com/zoomdata/connector/example/common/utils/CollectionUtils.java
@@ -1,16 +1,52 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.common.utils;
 
+import com.zoomdata.connector.example.common.utils.struct.Pair;
+import com.zoomdata.gen.edc.types.ListField;
+
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.util.Arrays.stream;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
 
 public final class CollectionUtils {
-    private CollectionUtils() { }
+    private CollectionUtils() {
+    }
+
+    public static <T1, T2> Map<T1, T2> merge(Map<T1, T2> mapPriorityLeast, Map<T1, T2> mapPriorityFirst) {
+        Map<T1, T2> newMap = new HashMap<>();
+
+        for (Map.Entry<T1, T2> entry : mapPriorityLeast.entrySet()) {
+            newMap.put(entry.getKey(), entry.getValue());
+        }
+
+        // override
+        for (Map.Entry<T1, T2> entry : mapPriorityFirst.entrySet()) {
+            newMap.put(entry.getKey(), entry.getValue());
+        }
+        return newMap;
+    }
+
+    public static int sumInts(int... numbers) {
+        int result = 0;
+        for (Integer i : numbers) {
+            result += i;
+        }
+        return result;
+    }
 
     public static boolean isEmpty(Collection c) {
         return c == null || c.isEmpty();
@@ -20,7 +56,35 @@ public final class CollectionUtils {
         return !isEmpty(c);
     }
 
+    public static List<ListField> collectionToListValues(Collection<? extends Object> collection) {
+        return collection.stream()
+                .map(value -> value == null ? new ListField().setIsNull(true) : new ListField().setValue(value.toString()))
+                .collect(toList());
+    }
+
     public static <T> List<T> union(List<T>... lists) {
         return stream(lists).flatMap(l -> l.stream()).collect(Collectors.toList());
+    }
+
+    public static <T, K, U, M extends Map<K, U>> Collector<T, ?, M> toSpecificMap(
+            Function<? super T, ? extends K> keyMapper,
+            Function<? super T, ? extends U> valueMapper,
+            Supplier<M> mapSupplier) {
+        return Collectors.toMap(
+                keyMapper,
+                valueMapper,
+                (u, v) -> {
+                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                },
+                mapSupplier);
+    }
+
+    public static <T> Stream<T> streamOfNullable(Collection<T> collection) {
+        return Optional.ofNullable(collection).orElse(emptyList()).stream();
+    }
+
+    public static  <T> Stream<Pair<Integer, T>> enumerate(Stream<T> stream) {
+        AtomicInteger incrementer = new AtomicInteger(0);
+        return stream.map(e -> Pair.create(incrementer.incrementAndGet(), e));
     }
 }

--- a/src/main/java/com/zoomdata/connector/example/common/utils/FieldMetaFlag.java
+++ b/src/main/java/com/zoomdata/connector/example/common/utils/FieldMetaFlag.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.common.utils;
 

--- a/src/main/java/com/zoomdata/connector/example/common/utils/FileUtils.java
+++ b/src/main/java/com/zoomdata/connector/example/common/utils/FileUtils.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.common.utils;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public final class FileUtils {
+    private FileUtils() { }
+
+    public static String readFile(String path) throws IOException {
+        byte[] encoded = Files.readAllBytes(Paths.get(path));
+        return new String(encoded, "UTF-8");
+    }
+
+    public static String readFileFromClassPath(String file) throws IOException {
+        try {
+            URL resourceUrl = FileUtils.class.getResource(file);
+            Path resourcePath = Paths.get(resourceUrl.toURI());
+            byte[] encoded = Files.readAllBytes(resourcePath);
+            return new String(encoded, "UTF-8");
+        } catch (URISyntaxException e) {
+            // FIXME wrong! do nothing
+            return "";
+        }
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/common/utils/MapUtils.java
+++ b/src/main/java/com/zoomdata/connector/example/common/utils/MapUtils.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.common.utils;
+
+import com.google.common.collect.Sets;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+public final class MapUtils {
+    public static boolean isEmpty(Map map) {
+        return map == null || map.isEmpty();
+    }
+
+    private MapUtils() {}
+
+    /**
+     * returns map that doesn't contain listed keys
+     *
+     * @param map  map that should be filtered
+     * @param keys keys that should be removed
+     */
+    public static <K, V> Map removeKeys(Map<K, V> map, String... keys) {
+        Set<String> filterSet = Sets.newHashSet(keys);
+        Map<K, V> result = new HashMap<>();
+        map.entrySet()
+                .stream()
+                .filter(e -> !filterSet.contains(e.getKey()))
+                .forEach(e -> result.put(e.getKey(), e.getValue()));
+        return result;
+    }
+
+    /**
+     * returns map that contains only listed values
+     *
+     * @param map    map that should be filtered
+     * @param values values that should be included in map
+     */
+    public static <K, V> Map filterValues(Map<K, V> map, V... values) {
+        Map<K, V> result = new HashMap<>();
+        Set<V> valueSet = Sets.newHashSet(values);
+        map.entrySet()
+                .stream()
+                .filter(e -> valueSet.contains(e.getValue()))
+                .forEach(e -> result.put(e.getKey(), e.getValue()));
+        return result;
+    }
+
+    /**
+     * returns map with transformed keys
+     * if Map is null -- it returns empty map,not null.
+     *
+     * @param map            map that should be transformed
+     * @param keyTransformer function that transforms keys
+     */
+    public static <K, V> Map<K, V> transformKeys(Map<K, V> map, Function<K, K> keyTransformer) {
+
+        if (MapUtils.isEmpty(map)) {
+            return Collections.emptyMap();
+        } else {
+            Map<K, V> result = new HashMap<>();
+            map.entrySet()
+                    .stream()
+                    .forEach(e -> result.put(keyTransformer.apply(e.getKey()), e.getValue()));
+            return result;
+        }
+    }
+
+    /**
+     * Returns specified map if it is not <tt>null</tt>; otherwise returns empty map.
+     *
+     * <p>Calling this method ensures that returned map is never <tt>null</tt>
+     * making all further operations performed on such map reference <tt>null</tt>-safe</p>
+     *
+     * @param map source map.
+     * @param <K> key type.
+     * @param <V> value type.
+     * @return specified map if it is not <tt>null</tt>; otherwise returns empty map.
+     */
+    @Nonnull
+    public static <K, V> Map<K, V> trimToEmpty(@Nullable Map<K, V> map) {
+        if (null == map) {
+            return Collections.emptyMap();
+        } else {
+            return map;
+        }
+    }
+
+}

--- a/src/main/java/com/zoomdata/connector/example/common/utils/StreamUtils.java
+++ b/src/main/java/com/zoomdata/connector/example/common/utils/StreamUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.common.utils;
 

--- a/src/main/java/com/zoomdata/connector/example/common/utils/StringUtils.java
+++ b/src/main/java/com/zoomdata/connector/example/common/utils/StringUtils.java
@@ -1,16 +1,45 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.common.utils;
+
+import com.google.common.escape.Escapers;
+
+import java.util.Set;
 
 public final class StringUtils {
 
     public static final String EMPTY = "";
+    private static final String SPACE = " ";
 
     private StringUtils() { }
 
     public static boolean isEmpty(String s) {
         return s == null || EMPTY.equals(s);
+    }
+
+    public static String space(int n) {
+        return repeat(n, SPACE);
+    }
+
+    public static String repeat(int n, String s) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < n; i++) {
+            sb.append(s);
+        }
+        return sb.toString();
+    }
+
+    public static String prependWithSpaces(String s, int n) {
+        StringBuilder sb = new StringBuilder();
+        String[] lines = s.split("\\n");
+        for (int i = 0; i < lines.length; i++) {
+            sb.append(space(n) + lines[i]);
+            if (i < lines.length - 1) {
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
     }
 
     public static String extractType(String s) {
@@ -22,4 +51,39 @@ public final class StringUtils {
         return processed;
     }
 
+    /**
+     * returns string before last entry of separator
+     * in case string doesn't contain separator -- returns whole string
+     *
+     * @param str       string that should be analyzed
+     * @param separator string that should separate string.
+     *                  Examples:
+     *                  subStringBeforeLast("aaaQQaQQde","QQ") = "aaaaQQ"
+     *                  subStringBeforeLast("aaaQQaQQde","test") = "aaaQQaQQde"
+     */
+
+    public static String subStringBeforeLast(String str, String separator) {
+        int from = str.lastIndexOf(separator);
+        return from == -1 ? str : str.substring(0, from);
+    }
+
+    public static int length(String schema) {
+        return isEmpty(schema) ? 0 : schema.length();
+    }
+
+    public static String toLowerOrNull(String s) {
+        return s == null ? null : s.toLowerCase();
+    }
+
+    public static String toUpperOrNull(String s) {
+        return s == null ? null : s.toUpperCase();
+    }
+
+    public static String prependEachCharacterWithString(String input, Set<Character> charsToPrepend, String prefix) {
+        Escapers.Builder escaperBuilder = Escapers.builder();
+        charsToPrepend.forEach(
+                character -> escaperBuilder.addEscape(character, prefix + character)
+        );
+        return escaperBuilder.build().escape(input);
+    }
 }

--- a/src/main/java/com/zoomdata/connector/example/common/utils/StructuredUtils.java
+++ b/src/main/java/com/zoomdata/connector/example/common/utils/StructuredUtils.java
@@ -1,0 +1,1067 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+
+package com.zoomdata.connector.example.common.utils;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.filter.FilterAND;
+import com.zoomdata.gen.edc.filter.FilterCONTAINS;
+import com.zoomdata.gen.edc.filter.FilterEQ;
+import com.zoomdata.gen.edc.filter.FilterEQI;
+import com.zoomdata.gen.edc.filter.FilterFunction;
+import com.zoomdata.gen.edc.filter.FilterGE;
+import com.zoomdata.gen.edc.filter.FilterGT;
+import com.zoomdata.gen.edc.filter.FilterIN;
+import com.zoomdata.gen.edc.filter.FilterISNULL;
+import com.zoomdata.gen.edc.filter.FilterLE;
+import com.zoomdata.gen.edc.filter.FilterLT;
+import com.zoomdata.gen.edc.filter.FilterNOT;
+import com.zoomdata.gen.edc.filter.FilterOR;
+import com.zoomdata.gen.edc.filter.FilterTEXT_SEARCH;
+import com.zoomdata.gen.edc.group.AttributeGroup;
+import com.zoomdata.gen.edc.group.Group;
+import com.zoomdata.gen.edc.group.GroupType;
+import com.zoomdata.gen.edc.group.HistogramGroup;
+import com.zoomdata.gen.edc.group.TimeGroup;
+import com.zoomdata.gen.edc.metric.Metric;
+import com.zoomdata.gen.edc.metric.MetricAvg;
+import com.zoomdata.gen.edc.metric.MetricCalc;
+import com.zoomdata.gen.edc.metric.MetricCount;
+import com.zoomdata.gen.edc.metric.MetricDistinctCount;
+import com.zoomdata.gen.edc.metric.MetricLastValue;
+import com.zoomdata.gen.edc.metric.MetricMax;
+import com.zoomdata.gen.edc.metric.MetricMin;
+import com.zoomdata.gen.edc.metric.MetricPercentile;
+import com.zoomdata.gen.edc.metric.MetricSum;
+import com.zoomdata.gen.edc.metric.MetricType;
+import com.zoomdata.gen.edc.request.AggDataRequest;
+import com.zoomdata.gen.edc.request.CollectionInfo;
+import com.zoomdata.gen.edc.request.DataReadRequest;
+import com.zoomdata.gen.edc.request.DistinctValuesRequest;
+import com.zoomdata.gen.edc.request.RawDataRequest;
+import com.zoomdata.gen.edc.request.StatField;
+import com.zoomdata.gen.edc.request.StatFunction;
+import com.zoomdata.gen.edc.request.StatsDataRequest;
+import com.zoomdata.gen.edc.request.StructuredRequest;
+import com.zoomdata.gen.edc.request.StructuredRequestType;
+import com.zoomdata.gen.edc.request.serverdescription.ConnectionParameter;
+import com.zoomdata.gen.edc.request.serverdescription.ParameterEnum;
+import com.zoomdata.gen.edc.request.serverdescription.ParameterInteger;
+import com.zoomdata.gen.edc.request.serverdescription.ParameterString;
+import com.zoomdata.gen.edc.request.serverdescription.ParameterType;
+import com.zoomdata.gen.edc.sort.AggSort;
+import com.zoomdata.gen.edc.sort.RawSort;
+import com.zoomdata.gen.edc.sort.SortDir;
+import com.zoomdata.gen.edc.sort.SortType;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import com.zoomdata.gen.edc.types.FieldParams;
+import com.zoomdata.gen.edc.types.FieldType;
+import com.zoomdata.gen.edc.types.PartitionParams;
+import com.zoomdata.gen.edc.types.TimeGranularity;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.zoomdata.connector.example.common.utils.FieldMetaFlag.PARTITION;
+import static com.zoomdata.connector.example.common.utils.FieldMetaFlag.PLAYABLE;
+import static com.zoomdata.connector.example.common.utils.FileUtils.readFileFromClassPath;
+import static com.zoomdata.connector.example.common.utils.metadatabuilders.Filters.isNull;
+import static com.zoomdata.connector.example.common.utils.metadatabuilders.Filters.not;
+import static com.zoomdata.connector.example.common.utils.metadatabuilders.Groups.group;
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
+import static java.util.Optional.of;
+import static java.util.Optional.ofNullable;
+
+public final class StructuredUtils {
+    private StructuredUtils() { }
+
+    private static final Map<String, Function<JSONObject, Filter>> FILTERS_MAP =
+            ImmutableMap.<String, Function<JSONObject, Filter>>builder()
+                    .put("and", StructuredUtils::processFilterAND)
+                    .put("or", StructuredUtils::processFilterOR)
+                    .put("not", StructuredUtils::processFilterNOT)
+                    .put("eq", StructuredUtils::processFilterEQ)
+                    .put("eqi", StructuredUtils::processFilterEQI)
+                    .put("in", StructuredUtils::processFilterIN)
+                    .put("ge", StructuredUtils::processFilterGE)
+                    .put("gt", StructuredUtils::processFilterGT)
+                    .put("le", StructuredUtils::processFilterLE)
+                    .put("lt", StructuredUtils::processFilterLT)
+                    .put("contains", StructuredUtils::processFilterCONTAINS)
+                    .put("is_null", StructuredUtils::processFilterISNULL)
+                    .put("text_search", StructuredUtils::processFilterTEXTSEARCH)
+                    .build();
+
+    private static final Map<String, BiFunction<JSONObject, StructuredRequest, StructuredRequest>> STRUCTURED_MAP =
+            ImmutableMap.<String, BiFunction<JSONObject, StructuredRequest, StructuredRequest>>builder()
+                    .put("raw", StructuredUtils::readRaw)
+                    .put("aggregated", StructuredUtils::readAggregated)
+                    .put("stats", StructuredUtils::readStats)
+                    .put("distinct_values", StructuredUtils::readDistinctValues)
+                    .build();
+
+    private static final Map<String, Function<JSONObject, Metric>> METRICS_MAP =
+            ImmutableMap.<String, Function<JSONObject, Metric>>builder()
+                    .put("sum", StructuredUtils::processMetricSUM)
+                    .put("min", StructuredUtils::processMetricMIN)
+                    .put("max", StructuredUtils::processMetricMAX)
+                    .put("avg", StructuredUtils::processMetricAVG)
+                    .put("count", StructuredUtils::processMetricCOUNT)
+                    .put("distinct_count", StructuredUtils::processMetricDISTINCTCOUNT)
+                    .put("last_value", StructuredUtils::processMetricLASTVALUE)
+                    .put("percentiles", StructuredUtils::processMetricPERCENTILES)
+                    .put("calculation", StructuredUtils::processMetricCALCULATION)
+                    .build();
+
+    private static final Map<String, Function<JSONObject, Group>> GROUP_MAP =
+            ImmutableMap.<String, Function<JSONObject, Group>>builder()
+                    .put("attribute_group", StructuredUtils::processAttributeGroup)
+                    .put("time_group", StructuredUtils::processTimeGroup)
+                    .put("histogram_group", StructuredUtils::processHistogramGroup)
+                    .build();
+
+    public static StructuredRequest parseToStructured(JSONObject rootJson, CollectionInfo colInfo) {
+        StructuredRequest structuredRequest = new StructuredRequest();
+        structuredRequest.setCollectionInfo(colInfo);
+        if (rootJson.has("fieldMetadata")) {
+            structuredRequest.setFieldMetadata(parseMetaData(rootJson.getJSONObject("fieldMetadata")));
+        }
+        String type = StringUtils.toLowerOrNull(rootJson.getString("type"));
+        BiFunction<JSONObject, StructuredRequest, StructuredRequest> parseFn = STRUCTURED_MAP.get(type);
+        if (parseFn == null) {
+            throw new IllegalArgumentException("Unsupported structured type: " + type);
+        } else {
+            return parseFn.apply(rootJson, structuredRequest);
+        }
+    }
+
+    public static DataReadRequest checkAndReplaceDistinctValuesRequestWithAggDataRequest(DataReadRequest request) {
+        if (request.isSetStructured() && request.getStructured().isSetDistinctValuesRequest()) {
+            StructuredRequest structured = request.getStructured();
+            DistinctValuesRequest distinctValuesRequest = structured.getDistinctValuesRequest();
+            Map<String, FieldMetadata> fieldMetadata = structured.getFieldMetadata();
+            DataReadRequest aggRequest = request.deepCopy();
+            aggRequest.getStructured().setType(StructuredRequestType.AGG);
+            aggRequest.getStructured().setAggDataRequest(convertToAggRequest(distinctValuesRequest, fieldMetadata));
+            return aggRequest;
+        }
+        return request;
+    }
+
+    public static AggDataRequest convertToAggRequest(DistinctValuesRequest distinctValuesRequest, Map<String, FieldMetadata> fieldMetadata) {
+        AggDataRequest aggDataRequest = new AggDataRequest();
+        String field = distinctValuesRequest.getField();
+        Group group = group(field);
+        aggDataRequest.setGroups(asList(group));
+
+        FieldType type = fieldMetadata.get(field).getType();
+        Filter isNotNullFilter = not(isNull(field, type));
+        List<Filter> filters = Lists.newArrayList(isNotNullFilter);
+        if (distinctValuesRequest.isSetFilters()) {
+            filters.addAll(distinctValuesRequest.getFilters());
+        }
+        aggDataRequest.setFilters(filters);
+
+        if (distinctValuesRequest.isSetLimit()) {
+            aggDataRequest.setLimit(distinctValuesRequest.getLimit());
+        }
+        if (distinctValuesRequest.isSetOffset()) {
+            aggDataRequest.setOffset(distinctValuesRequest.getOffset());
+        }
+        SortDir sortDir = distinctValuesRequest.isSetSort()
+                ? distinctValuesRequest.getSort().getDirection()
+                : SortDir.ASC;
+        aggDataRequest.setSorts(Collections.singletonList(
+                new AggSort(SortType.GROUP)
+                        .setDirection(sortDir)
+                        .setGroup(group)
+        ));
+        return aggDataRequest;
+    }
+
+    private static StructuredRequest readAggregated(JSONObject json, StructuredRequest request) {
+        AggDataRequest aggDataRequest = new AggDataRequest();
+        aggDataRequest.setGroups(parseGroups(json));
+        aggDataRequest.setMetrics(parseMetrics(json));
+        aggDataRequest.setFilters(parseFilters(json));
+        aggDataRequest.setSorts(parseAggSorts(json));
+
+        Integer limit = parseLimit(json);
+        if (limit != null) {
+            aggDataRequest.setLimit(limit);
+        }
+
+        Integer offset = parseOffset(json);
+        if (offset != null) {
+            aggDataRequest.setOffset(offset);
+        }
+
+        request.setType(StructuredRequestType.AGG);
+        request.setAggDataRequest(aggDataRequest);
+        return request;
+    }
+
+    private static List<Group> parseGroups(JSONObject json) {
+        List<Group> groups = new ArrayList<>();
+        if (json.has("groups")) {
+            JSONArray groupsArray = json.getJSONArray("groups");
+            if (groupsArray != null) {
+                for (int i = 0; i < groupsArray.length(); i++) {
+                    JSONObject groupJson = groupsArray.getJSONObject(i);
+                    String type = StringUtils.toLowerOrNull(groupJson.getString("type"));
+                    Function<JSONObject, Group> group = GROUP_MAP.get(type);
+                    if (group == null) {
+                        throw new IllegalArgumentException("Invalid group: " + type);
+                    } else {
+                        groups.add(group.apply(groupJson));
+                    }
+                }
+            }
+        }
+        return groups;
+    }
+
+    private static Group processAttributeGroup(JSONObject json) {
+        Group group = new Group();
+        group.setType(GroupType.ATTRIBUTE_GROUP);
+        group.setAttributeGroup(new AttributeGroup().setField(json.getString("field")));
+        return group;
+    }
+
+    private static Group processTimeGroup(JSONObject json) {
+        Group group = new Group();
+        group.setType(GroupType.TIME_GROUP);
+        group.setTimeGroup(new TimeGroup()
+                .setField(json.getString("field"))
+                .setGranularity(TimeGranularity.valueOf(json.getString("granularity"))));
+        return group;
+    }
+
+    private static Group processHistogramGroup(JSONObject json) {
+        Group group = new Group();
+        group.setType(GroupType.HISTOGRAM_GROUP);
+        group.setHistogramGroup(new HistogramGroup()
+                .setField(json.getString("field"))
+                .setBucketSize(json.getDouble("bucket_size"))
+                .setStartPoint(json.getDouble("start_point"))
+                .setEndPoint(json.getDouble("end_point"))
+        );
+        return group;
+    }
+
+    private static List<Metric> parseMetrics(JSONObject json) {
+        JSONArray metricsArray = json.getJSONArray("metrics");
+        List<Metric> metrics = new ArrayList<>();
+        if (metricsArray != null) {
+            for (int i = 0; i < metricsArray.length(); i++) {
+                JSONObject metricJson = metricsArray.getJSONObject(i);
+                String type = StringUtils.toLowerOrNull(metricJson.getString("type"));
+                Function<JSONObject, Metric> parseFn = METRICS_MAP.get(type);
+                if (parseFn == null) {
+                    throw new IllegalArgumentException("Invalid metric type: " + type);
+                } else {
+                    metrics.add(parseFn.apply(metricJson));
+                }
+            }
+        }
+        return metrics;
+    }
+
+    private static Metric processMetricSUM(JSONObject json) {
+        Metric metric = new Metric();
+        metric.setType(MetricType.SUM);
+        metric.setSum(new MetricSum().setField(json.getString("field")));
+        return metric;
+    }
+
+    private static Metric processMetricMIN(JSONObject json) {
+        Metric metric = new Metric();
+        metric.setType(MetricType.MIN);
+        metric.setMin(new MetricMin().setField(json.getString("field")));
+        return metric;
+    }
+
+    private static Metric processMetricMAX(JSONObject json) {
+        Metric metric = new Metric();
+        metric.setType(MetricType.MAX);
+        metric.setMax(new MetricMax().setField(json.getString("field")));
+        return metric;
+    }
+
+    private static Metric processMetricAVG(JSONObject json) {
+        Metric metric = new Metric();
+        metric.setType(MetricType.AVG);
+        metric.setAvg(new MetricAvg().setField(json.getString("field")));
+        return metric;
+    }
+
+    private static Metric processMetricCOUNT(JSONObject json) {
+        Metric metric = new Metric();
+        metric.setType(MetricType.COUNT);
+        MetricCount metricCount = new MetricCount();
+        if (json.has("field")) {
+            metricCount.setField(json.getString("field"));
+        }
+        metric.setCount(metricCount);
+        return metric;
+    }
+
+    private static Metric processMetricLASTVALUE(JSONObject json) {
+        Metric metric = new Metric();
+        metric.setType(MetricType.LAST_VALUE);
+        metric.setLastValue(new MetricLastValue()
+                .setField(json.getString("field"))
+                .setTimeField(json.getString("time_field"))
+        );
+        return metric;
+    }
+
+    private static Metric processMetricDISTINCTCOUNT(JSONObject json) {
+        Metric metric = new Metric();
+        metric.setType(MetricType.DISTINCT_COUNT);
+        metric.setDistinctCount(new MetricDistinctCount()
+                .setField(json.getString("field"))
+        );
+        return metric;
+    }
+
+    private static Metric processMetricPERCENTILES(JSONObject json) {
+        Metric metric = new Metric();
+        metric.setType(MetricType.PERCENTILES);
+        MetricPercentile metricPercentiles = new MetricPercentile();
+        metricPercentiles.setField(json.getString("field"));
+        metricPercentiles.setMargin(json.getDouble("margin"));
+        metric.setPercentile(metricPercentiles);
+        return metric;
+    }
+
+    private static Metric processMetricCALCULATION(JSONObject json) {
+        Metric metric = new Metric();
+        metric.setType(MetricType.CALC);
+        metric.setCalculation(new MetricCalc().setValue(json.getString("value")));
+        return metric;
+    }
+
+    private static StructuredRequest readDistinctValues(JSONObject json, StructuredRequest structuredRequest) {
+        DistinctValuesRequest distinctValuesRequest = new DistinctValuesRequest();
+        distinctValuesRequest.setField(parseField(json));
+        distinctValuesRequest.setFilters(parseFilters(json));
+        Integer limit = parseLimit(json);
+        if (limit != null) {
+            distinctValuesRequest.setLimit(limit);
+        }
+
+        Integer offset = parseOffset(json);
+        if (offset != null) {
+            distinctValuesRequest.setOffset(offset);
+        }
+
+        structuredRequest.setType(StructuredRequestType.DISTINCT_VALUES);
+        structuredRequest.setDistinctValuesRequest(distinctValuesRequest);
+        return structuredRequest;
+    }
+
+    private static StructuredRequest readRaw(JSONObject json, StructuredRequest request) {
+        RawDataRequest rawDataRequest = new RawDataRequest();
+
+
+        rawDataRequest.setFields(parseFields(json));
+        rawDataRequest.setFilters(parseFilters(json));
+        rawDataRequest.setSorts(parseRawSorts(json));
+
+        Integer limit = parseLimit(json);
+        if (limit != null) {
+            rawDataRequest.setLimit(limit);
+        }
+
+        Integer offset = parseOffset(json);
+        if (offset != null) {
+            rawDataRequest.setOffset(offset);
+        }
+
+        request.setType(StructuredRequestType.RAW);
+        request.setRawDataRequest(rawDataRequest);
+        return request;
+    }
+
+    private static StructuredRequest readStats(JSONObject json, StructuredRequest request) {
+        StatsDataRequest statsDataRequest = new StatsDataRequest();
+        statsDataRequest.setStatFields(parseStatFields(json));
+        request.setType(StructuredRequestType.STATS);
+        request.setStatsDataRequest(statsDataRequest);
+        return request;
+    }
+
+    private static String parseField(JSONObject json) {
+        return json.getString("field");
+    }
+
+    private static List<StatField> parseStatFields(JSONObject json) {
+        JSONArray statFieldsArray = json.getJSONArray("stat_fields");
+        if (statFieldsArray == null || statFieldsArray.length() == 0) {
+            throw new IllegalArgumentException("Field 'stat_fields' is required");
+        }
+        List<StatField> statFields = new ArrayList<>();
+        for (int i = 0; i < statFieldsArray.length(); i++) {
+            String field = statFieldsArray.getJSONObject(i).getString("field");
+            String statFunction = statFieldsArray.getJSONObject(i).getString("function");
+            statFields.add(new StatField(field, StatFunction.valueOf(statFunction)));
+        }
+        return statFields;
+    }
+
+    private static List<RawSort> parseRawSorts(JSONObject json) {
+        List<RawSort> sorts = new ArrayList<>();
+        if (json.has("sorts")) {
+            JSONArray sortsArray = json.getJSONArray("sorts");
+            if (sortsArray != null && sortsArray.length() > 0) {
+                for (int i = 0; i < sortsArray.length(); i++) {
+                    sorts.add(processJsonRawSort(sortsArray.getJSONObject(i)));
+                }
+            }
+        }
+        return sorts;
+    }
+
+    private static RawSort processJsonRawSort(JSONObject jsonObject) {
+        RawSort sort = new RawSort();
+        sort.setField(jsonObject.getString("field"));
+        sort.setDirection(SortDir.valueOf(StringUtils.toUpperOrNull(jsonObject.getString("dir"))));
+        return sort;
+    }
+
+    private static List<AggSort> parseAggSorts(JSONObject json) {
+        List<AggSort> sorts = new ArrayList<>();
+        if (json.has("sorts")) {
+            JSONArray sortsArray = json.getJSONArray("sorts");
+            if (sortsArray != null && sortsArray.length() > 0) {
+                for (int i = 0; i < sortsArray.length(); i++) {
+                    sorts.add(processJsonAggSort(sortsArray.getJSONObject(i)));
+                }
+            }
+        }
+        return sorts;
+    }
+
+    private static AggSort processJsonAggSort(JSONObject jsonObject) {
+        AggSort sort = new AggSort();
+        sort.setType(SortType.valueOf(jsonObject.getString("type")));
+        sort.setDirection(SortDir.valueOf(StringUtils.toUpperOrNull(jsonObject.getString("dir"))));
+
+        if (sort.getType() == SortType.GROUP) {
+            JSONObject groupJson = jsonObject.getJSONObject("group");
+            String type = StringUtils.toLowerOrNull(groupJson.getString("type"));
+            Function<JSONObject, Group> group = GROUP_MAP.get(type);
+            if (group == null) {
+                throw new IllegalArgumentException("Unsuported group type: " + type);
+            } else {
+                sort.setGroup(group.apply(groupJson));
+            }
+        } else {
+            JSONObject metricJson = jsonObject.getJSONObject("metric");
+            String type = StringUtils.toLowerOrNull(metricJson.getString("type"));
+            Function<JSONObject, Metric> parseFn = METRICS_MAP.get(type);
+            if (parseFn == null) {
+                throw new IllegalArgumentException("Unsupported metric type: " + type);
+            } else {
+                sort.setMetric(parseFn.apply(metricJson));
+            }
+        }
+
+        return sort;
+    }
+
+    private static List<Filter> parseFilters(JSONObject json) {
+        List<Filter> filters = new ArrayList<>();
+        if (json.has("filters")) {
+            JSONArray filtersArray = json.getJSONArray("filters");
+            if (filtersArray != null && filtersArray.length() > 0) {
+                for (int i = 0; i < filtersArray.length(); i++) {
+                    filters.add(processJsonFilter(filtersArray.getJSONObject(i)));
+                }
+            }
+        }
+        return filters;
+    }
+
+    private static Filter processJsonFilter(JSONObject jsonFilter) {
+        String type = jsonFilter.getString("type") == null ? null : jsonFilter.getString("type").toLowerCase();
+        Function<JSONObject, Filter> filterParseFN = FILTERS_MAP.get(type);
+        if (filterParseFN == null) {
+            throw new IllegalArgumentException("Unsuported filter type: " + type);
+        } else {
+            return filterParseFN.apply(jsonFilter);
+        }
+    }
+
+    private static Filter processFilterIN(JSONObject jsonFilter) {
+        Filter filter = new Filter();
+        FilterIN filterIN = new FilterIN();
+
+        filterIN.setPath(jsonFilter.getString("field_path"));
+        filterIN.setType(FieldType.valueOf(jsonFilter.getString("field_type")));
+
+        JSONArray filterValues = jsonFilter.getJSONArray("values");
+        if (filterValues != null) {
+            List<Field> values = new ArrayList<>();
+            for (int i = 0; i < filterValues.length(); i++) {
+                values.add(new Field().setValue(filterValues.getString(i)));
+            }
+            filterIN.setValues(values);
+        }
+        filter.setType(FilterFunction.IN);
+        filter.setFilterIN(filterIN);
+        return filter;
+    }
+
+    private static Filter processFilterEQ(JSONObject jsonFilter) {
+        Filter filter = new Filter();
+        FilterEQ filterEQ = new FilterEQ();
+
+        filterEQ.setPath(jsonFilter.getString("field_path"));
+        filterEQ.setType(FieldType.valueOf(jsonFilter.getString("field_type")));
+        filterEQ.setValue(new Field().setValue(jsonFilter.getString("value")));
+
+        filter.setType(FilterFunction.EQ);
+        filter.setFilterEQ(filterEQ);
+        return filter;
+    }
+
+    private static Filter processFilterISNULL(JSONObject jsonFilter) {
+        Filter filter = new Filter();
+        FilterISNULL filterISNULL = new FilterISNULL();
+
+        filterISNULL.setPath(jsonFilter.getString("field_path"));
+        filterISNULL.setType(FieldType.valueOf(jsonFilter.getString("field_type")));
+
+        filter.setType(FilterFunction.IS_NULL);
+        filter.setFilterISNULL(filterISNULL);
+        return filter;
+    }
+
+    private static Filter processFilterCONTAINS(JSONObject jsonFilter) {
+        Filter filter = new Filter();
+        FilterCONTAINS filterCONTAINS = new FilterCONTAINS();
+
+        filterCONTAINS.setPath(jsonFilter.getString("field_path"));
+        filterCONTAINS.setValue(new Field().setValue(jsonFilter.getString("value")));
+
+        filter.setType(FilterFunction.CONTAINS);
+        filter.setFilterCONTAINS(filterCONTAINS);
+        return filter;
+    }
+
+    private static Filter processFilterTEXTSEARCH(JSONObject jsonFilter) {
+        Filter filter = new Filter();
+        FilterTEXT_SEARCH filterTS = new FilterTEXT_SEARCH();
+
+        filterTS.setPath(jsonFilter.getString("field_path"));
+        filterTS.setValue(jsonFilter.getString("value"));
+
+        filter.setType(FilterFunction.TEXT_SEARCH);
+        filter.setFilterTEXT_SEARCH(filterTS);
+        return filter;
+    }
+
+    private static Filter processFilterEQI(JSONObject jsonFilter) {
+        Filter filter = new Filter();
+        FilterEQI filterEQI = new FilterEQI();
+
+        filterEQI.setPath(jsonFilter.getString("field_path"));
+        filterEQI.setValue(new Field().setValue(jsonFilter.getString("value")));
+
+        filter.setType(FilterFunction.EQI);
+        filter.setFilterEQI(filterEQI);
+        return filter;
+    }
+
+    private static Filter processFilterGE(JSONObject jsonFilter) {
+        Filter filter = new Filter();
+        FilterGE filterGE = new FilterGE();
+
+        filterGE.setPath(jsonFilter.getString("field_path"));
+        filterGE.setType(FieldType.valueOf(jsonFilter.getString("field_type")));
+        filterGE.setValue(new Field().setValue(jsonFilter.getString("value")));
+
+        filter.setType(FilterFunction.GE);
+        filter.setFilterGE(filterGE);
+        return filter;
+    }
+
+    private static Filter processFilterGT(JSONObject jsonFilter) {
+        Filter filter = new Filter();
+        FilterGT filterGT = new FilterGT();
+
+        filterGT.setPath(jsonFilter.getString("field_path"));
+        filterGT.setType(FieldType.valueOf(jsonFilter.getString("field_type")));
+        filterGT.setValue(new Field().setValue(jsonFilter.getString("value")));
+
+        filter.setType(FilterFunction.GT);
+        filter.setFilterGT(filterGT);
+        return filter;
+    }
+
+    private static Filter processFilterLT(JSONObject jsonFilter) {
+        Filter filter = new Filter();
+        FilterLT filterLT = new FilterLT();
+
+        filterLT.setPath(jsonFilter.getString("field_path"));
+        filterLT.setType(FieldType.valueOf(jsonFilter.getString("field_type")));
+        filterLT.setValue(new Field().setValue(jsonFilter.getString("value")));
+
+        filter.setType(FilterFunction.LT);
+        filter.setFilterLT(filterLT);
+        return filter;
+    }
+
+    private static Filter processFilterLE(JSONObject jsonFilter) {
+        Filter filter = new Filter();
+        FilterLE filterLE = new FilterLE();
+
+        filterLE.setPath(jsonFilter.getString("field_path"));
+        filterLE.setType(FieldType.valueOf(jsonFilter.getString("field_type")));
+        filterLE.setValue(new Field().setValue(jsonFilter.getString("value")));
+
+        filter.setType(FilterFunction.LE);
+        filter.setFilterLE(filterLE);
+        return filter;
+    }
+
+    private static Filter processFilterNOT(JSONObject jsonFilter) {
+        Filter filter = new Filter();
+        FilterNOT filterNOT = new FilterNOT();
+        filterNOT.setFilter(processJsonFilter(jsonFilter.getJSONObject("filter")));
+        filter.setType(FilterFunction.NOT);
+        filter.setFilterNOT(filterNOT);
+        return filter;
+    }
+
+    private static Filter processFilterAND(JSONObject jsonFilter) {
+        Filter filter = new Filter();
+        FilterAND filterAND = new FilterAND();
+        List<Filter> filters = new ArrayList<>();
+        JSONArray filtersArray = jsonFilter.getJSONArray("filters");
+        for (int i = 0; i < filtersArray.length(); i++) {
+            filters.add(processJsonFilter(filtersArray.getJSONObject(i)));
+        }
+        filterAND.setFilters(filters);
+        filter.setType(FilterFunction.AND);
+        filter.setFilterAND(filterAND);
+        return filter;
+    }
+
+    private static Filter processFilterOR(JSONObject jsonFilter) {
+        Filter filter = new Filter();
+        FilterOR filterOR = new FilterOR();
+        List<Filter> filters = new ArrayList<>();
+        JSONArray filtersArray = jsonFilter.getJSONArray("filters");
+        for (int i = 0; i < filtersArray.length(); i++) {
+            filters.add(processJsonFilter(filtersArray.getJSONObject(i)));
+        }
+        filterOR.setFilters(filters);
+        filter.setType(FilterFunction.OR);
+        filter.setFilterOR(filterOR);
+        return filter;
+    }
+
+    private static Integer parseLimit(JSONObject json) {
+        if (json.has("limit")) {
+            return json.getInt("limit");
+        }
+        return null;
+    }
+
+    private static Integer parseOffset(JSONObject json) {
+        if (json.has("offset")) {
+            return json.getInt("offset");
+        }
+        return null;
+    }
+
+    private static List<String> parseFields(JSONObject json) {
+        // extract fields
+        JSONArray fieldsArray = json.getJSONArray("fields");
+        // validate fields
+        if (fieldsArray == null) {
+            throw new IllegalArgumentException("field 'fields' not found");
+        }
+        // process fields
+        List<String> fields = new ArrayList<>();
+        for (int i = 0; i < fieldsArray.length(); i++) {
+            String field = fieldsArray.getString(i);
+            fields.add(field);
+        }
+        return fields;
+    }
+
+    public static Map<String, FieldMetadata> parseMetaData(JSONObject json) {
+        if (json != null) {
+            return json.keySet().stream().collect(Collectors.toMap(
+                    k -> k,
+                    k -> parseFieldMetaData(json.getJSONObject(k))
+            ));
+        } else {
+            return null;
+        }
+    }
+
+    private static FieldMetadata parseFieldMetaData(JSONObject json) {
+        FieldMetadata fieldMetadata = new FieldMetadata();
+        getJSON(json, "params")
+                .ifPresent(v -> {
+                    Map<String, String> params = v.keySet().stream().collect(Collectors.toMap(
+                            k -> k,
+                            v::getString
+                    ));
+                    fieldMetadata.setParams(params);
+                });
+        getJSON(json, "fieldParams")
+                .ifPresent(jsonFieldParams -> {
+                    FieldParams fieldParams = new FieldParams();
+                    fieldMetadata.setFieldParams(fieldParams);
+                    getString(jsonFieldParams, "label")
+                            .ifPresent(fieldParams::setFieldLabel);
+                    getString(jsonFieldParams, "timeFieldPattern")
+                            .ifPresent(fieldParams::setTimeFieldPattern);
+                    getString(jsonFieldParams, "timeFieldGranularity")
+                            .ifPresent(v -> fieldParams.setTimeFieldGranularity(TimeGranularity.valueOf(v)));
+                    getBoolean(jsonFieldParams, "isVisible")
+                            .ifPresent(fieldParams::setIsVisible);
+                    getBoolean(jsonFieldParams, "isPlayable").filter(isPlayable -> isPlayable)
+                            .ifPresent(v -> FieldMetaFlag.addFlags(fieldMetadata, PLAYABLE));
+                    getBoolean(jsonFieldParams, "isPartition").filter(isPartition -> isPartition)
+                            .ifPresent(v -> FieldMetaFlag.addFlags(fieldMetadata, PARTITION));
+                    getStringList(jsonFieldParams, "flags")
+                            .ifPresent(list -> {
+                                FieldMetaFlag[] flags = list.stream()
+                                        .map(FieldMetaFlag::valueOf)
+                                        .toArray(FieldMetaFlag[]::new);
+                                FieldMetaFlag.addFlags(fieldMetadata, flags);
+                            });
+                });
+        getString(json, "type")
+                .ifPresent(v -> fieldMetadata.setType(FieldType.valueOf(v)));
+        getString(json, "name")
+                .ifPresent(fieldMetadata::setName);
+        getJSON(json, "partitionParams")
+                .ifPresent(jsonPartitionParams -> {
+                    PartitionParams partitionParams = new PartitionParams();
+                    getString(jsonPartitionParams, "fieldName").ifPresent(partitionParams::setFieldName);
+                    getString(jsonPartitionParams, "func").ifPresent(partitionParams::setFunc);
+                    fieldMetadata.setPartitionParams(partitionParams);
+                });
+        return fieldMetadata;
+
+    }
+
+    private static Optional<String> getString(JSONObject json, String value) {
+        return json.has(value) && !json.isNull(value) ?
+                Optional.of(json.getString(value)) :
+                Optional.empty();
+    }
+
+    private static Optional<Boolean> getBoolean(JSONObject json, String value) {
+        return json.has(value) && !json.isNull(value) ?
+                Optional.of(json.getBoolean(value)) :
+                Optional.empty();
+    }
+
+    private static Optional<List<String>> getStringList(JSONObject json, String value) {
+        if (json.has(value) && !json.isNull(value)) {
+            JSONArray values = json.getJSONArray(value);
+            return of(IntStream.range(0, values.length())
+                    .mapToObj(values::getString)
+                    .collect(Collectors.toList()));
+        } else {
+            return Optional.empty();
+        }
+
+    }
+
+    private static Optional<JSONObject> getJSON(JSONObject json, String value) {
+        return json.has(value) && !JSONObject.NULL.equals(json.get(value)) ?
+                Optional.of(json.getJSONObject(value)) :
+                Optional.empty();
+    }
+
+    public static <T> T retrieveAndTransformOrDefault(Map<String, String> params,
+                                                      String name,
+                                                      Function<String, T> converter,
+                                                      T defaultValue) {
+        if (MapUtils.isEmpty(params) || !params.containsKey(name)) {
+            return defaultValue;
+        } else {
+            return converter.apply(params.get(name));
+        }
+    }
+
+    public static StructuredRequest readStructuredRequest(String jsonName, CollectionInfo collectionInfo)
+            throws IOException {
+        JSONObject json = new JSONObject(readFileFromClassPath(jsonName));
+        return StructuredUtils.parseToStructured(json, collectionInfo);
+    }
+
+    public static boolean hasPercentile(StructuredRequest request) {
+        AggDataRequest aggDataRequest = request.getAggDataRequest();
+        if (aggDataRequest != null) {
+            List<Metric> metrics = aggDataRequest.getMetrics();
+            if (metrics != null && !metrics.isEmpty()) {
+                return metrics.stream().anyMatch(metric -> metric.getType() == MetricType.PERCENTILES);
+            }
+        }
+        return false;
+    }
+
+    public static void setParam(FieldMetadata field, String param, String value) {
+        Map<String, String> params = ofNullable(field.getParams())
+                .orElse(new HashMap<>());
+        params.put(param, value);
+        field.setParams(params);
+    }
+
+    public static String getParam(FieldMetadata field, String param, String defaultValue) {
+        return ofNullable(ofNullable(
+                field.getParams())
+                .orElse(new HashMap<>())
+                .get(param))
+                .orElse(defaultValue);
+    }
+
+    public static boolean isGlobalGroup(StructuredRequest request) {
+        return StructuredRequestType.AGG == request.getType() && CollectionUtils.isEmpty(request.getAggDataRequest().getGroups());
+    }
+
+    public static boolean hasFlags(FieldMetadata field, FieldMetaFlag... flags) {
+        if (field.getFieldParams() == null || field.getFieldParams().getFlags() == null) {
+            return false;
+        } else {
+            List<String> requiredFlags = stream(flags).map(Enum::toString).collect(Collectors.toList());
+            return field.getFieldParams().getFlags().containsAll(requiredFlags);
+        }
+    }
+
+    public static boolean isFilterTextSearchOnAllDocument(Filter f) {
+        return f.getType() == FilterFunction.TEXT_SEARCH
+                && StringUtils.isEmpty(f.getFilterTEXT_SEARCH().getPath());
+    }
+
+    public static List<Filter> flattenFilters(List<Filter> filters) {
+        return flattenFilters(filters.toArray(new Filter[filters.size()]));
+    }
+
+    public static List<Filter> flattenFilters(Filter... filters) {
+        return Arrays.stream(filters).flatMap(f -> {
+            switch (f.getType()) {
+                case AND: {
+                    return f.getFilterAND().getFilters().stream()
+                            .flatMap(s -> flattenFilters(s).stream());
+                }
+                case OR: {
+                    return f.getFilterOR().getFilters().stream()
+                            .flatMap(s -> flattenFilters(s).stream());
+                }
+                case NOT: {
+                    FilterNOT filterNOT = f.getFilterNOT();
+                    return flattenFilters(filterNOT.getFilter()).stream();
+                }
+                default: {
+                    return Stream.of(f);
+                }
+            }
+        }).collect(Collectors.toList());
+    }
+
+
+    public static boolean isFilterOfTypeAndField(Filter filter, String field, FilterFunction filterType) {
+        if (!filter.getType().equals(filterType)) {
+            return false;
+        } else {
+            switch (filterType) {
+                case GE:
+                    return filter.getFilterGE().getPath().equals(field);
+                case GT:
+                    return filter.getFilterGT().getPath().equals(field);
+                case LE:
+                    return filter.getFilterLE().getPath().equals(field);
+                case LT:
+                    return filter.getFilterLT().getPath().equals(field);
+                case EQ:
+                    return filter.getFilterEQ().getPath().equals(field);
+                case EQI:
+                    return filter.getFilterEQI().getPath().equals(field);
+                case IN:
+                    return filter.getFilterIN().getPath().equals(field);
+                case IS_NULL:
+                    return filter.getFilterISNULL().getPath().equals(field);
+                case CONTAINS:
+                    return filter.getFilterCONTAINS().getPath().equals(field);
+                case ENDS_WITH:
+                    return filter.getFilterENDS_WITH().getPath().equals(field);
+                case STARTS_WITH:
+                    return filter.getFilterSTARTS_WITH().getPath().equals(field);
+                case TEXT_SEARCH:
+                    return !StringUtils.isEmpty(filter.getFilterTEXT_SEARCH().getPath())
+                            && filter.getFilterTEXT_SEARCH().getPath().equals(field);
+                default:
+                    return false;
+            }
+        }
+    }
+
+    public static ConnectionParameter convertConnectionParameter(JSONObject input) {
+        ParameterType type = ParameterType.valueOf(input.getString("type"));
+        ConnectionParameter param = new ConnectionParameter();
+        param.setName(input.getString("name"));
+        param.setType(type);
+        param.setIsRequired(input.getBoolean("isRequired"));
+        if (input.has("description")) {
+            param.setDescription(input.getString("description"));
+        }
+        switch (type) {
+            case STRING: {
+                param.setParameterString(convertStringProperties(input));
+                break;
+            }
+            case ENUM: {
+                param.setParameterEnum(convertEnumProperties(input));
+                break;
+            }
+            case INTEGER: {
+                param.setParameterInteger(convertIntProperties(input));
+                break;
+            }
+        }
+        return param;
+    }
+
+    private static ParameterInteger convertIntProperties(JSONObject input) {
+        ParameterInteger intProperties = new ParameterInteger();
+        if (input.has("parameterInteger")) {
+            JSONObject paramsJson = input.getJSONObject("parameterInteger");
+            if (paramsJson.has("min")) {
+                intProperties.setMin(paramsJson.getInt("min"));
+            }
+            if (paramsJson.has("max")) {
+                intProperties.setMax(paramsJson.getInt("max"));
+            }
+        }
+        return intProperties;
+    }
+
+    private static ParameterEnum convertEnumProperties(JSONObject input) {
+        ParameterEnum parameterEnum = new ParameterEnum();
+        if (input.has("parameterEnum")) {
+            JSONObject paramsJson = input.getJSONObject("parameterEnum");
+            if (paramsJson.has("values")) {
+                JSONArray valuesArray = paramsJson.getJSONArray("values");
+                List<String> values = IntStream.range(0, valuesArray.length())
+                        .mapToObj(valuesArray::getString)
+                        .collect(Collectors.toList());
+                parameterEnum.setValues(values);
+            }
+        }
+        return parameterEnum;
+    }
+
+    private static ParameterString convertStringProperties(JSONObject input) {
+        ParameterString stringProperties = new ParameterString();
+        if (input.has("parameterString")) {
+            JSONObject strPropertiesJson = input.getJSONObject("parameterString");
+            if (strPropertiesJson.has("maxLength")) {
+                stringProperties.setMaxLength(strPropertiesJson.getInt("maxLength"));
+            }
+        }
+        return stringProperties;
+    }
+
+    public static String getMetricName(Metric metric) {
+        switch (metric.getType()) {
+            case SUM:
+                return metric.getSum().getField();
+            case COUNT:
+                return metric.getCount().getField();
+            case AVG:
+                return metric.getAvg().getField();
+            case MIN:
+                return metric.getMin().getField();
+            case MAX:
+                return metric.getMax().getField();
+            case PERCENTILES:
+                return metric.getPercentile().getField();
+            case LAST_VALUE:
+                return metric.getLastValue().getField();
+            case DISTINCT_COUNT:
+                return metric.getDistinctCount().getField();
+            default:
+                throw new IllegalArgumentException("unknown metric type " + metric.getType());
+        }
+    }
+
+    public static String getFilterName(Filter filter) {
+        if (asList(FilterFunction.AND, FilterFunction.NOT, FilterFunction.OR)
+                .contains(filter.getType())) {
+            throw new IllegalArgumentException("filter name can be retrieved only for simple filters");
+        }
+        switch (filter.getType()) {
+            case GE:
+                return filter.getFilterGE().getPath();
+            case GT:
+                return filter.getFilterGT().getPath();
+            case LE:
+                return filter.getFilterLE().getPath();
+            case LT:
+                return filter.getFilterLT().getPath();
+            case EQI:
+                return filter.getFilterEQI().getPath();
+            case EQ:
+                return filter.getFilterEQ().getPath();
+            case ENDS_WITH:
+                return filter.getFilterENDS_WITH().getPath();
+            case STARTS_WITH:
+                return filter.getFilterSTARTS_WITH().getPath();
+            case TEXT_SEARCH:
+                return filter.getFilterTEXT_SEARCH().getPath();
+            case IS_NULL:
+                return filter.getFilterISNULL().getPath();
+            case IN:
+                return filter.getFilterIN().getPath();
+            case CONTAINS:
+                return filter.getFilterCONTAINS().getPath();
+            default:
+                throw new IllegalArgumentException("unknown filter type " + filter.getType());
+        }
+    }
+
+    public static String getGroupName(Group group) {
+        switch (group.getType()) {
+            case HISTOGRAM_GROUP:
+                return group.getHistogramGroup().getField();
+            case TIME_GROUP:
+                return group.getTimeGroup().getField();
+            case ATTRIBUTE_GROUP:
+                return group.getAttributeGroup().getField();
+            default:
+                throw new IllegalArgumentException("unknown group type " + group.getType());
+        }
+    }
+
+}
+

--- a/src/main/java/com/zoomdata/connector/example/common/utils/ThriftUtils.java
+++ b/src/main/java/com/zoomdata/connector/example/common/utils/ThriftUtils.java
@@ -1,21 +1,59 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.common.utils;
 
+import com.zoomdata.gen.edc.ConnectorService;
 import com.zoomdata.gen.edc.request.CollectionInfo;
 import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldType;
+import org.apache.thrift.protocol.TCompactProtocol;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.THttpClient;
+import org.apache.thrift.transport.TSSLTransportFactory;
+import org.apache.thrift.transport.TSocket;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
 import java.util.Collections;
+import java.util.Date;
 
 public final class ThriftUtils {
     public ThriftUtils() { }
 
+    private static final String HTTP_PROTOCOL = "http";
+    private static final String HTTPS_PROTOCOL = "https";
+    private static final String HTTP_CLIENT_FORMAT = "%s://%s:%s/connector/";
     private static DateTimeFormatter DATE_TIME_FORMATTER = ISODateTimeFormat.dateTime().withZone(DateTimeZone.UTC);
+
+
+    public static ConnectorService.Client createHttpClient(String host, int port, boolean useSSL) throws TTransportException {
+        TTransport transport = new THttpClient(
+                String.format(HTTP_CLIENT_FORMAT, (useSSL) ? HTTPS_PROTOCOL : HTTP_PROTOCOL , host, port));
+        TProtocol protocol = new TCompactProtocol.Factory().getProtocol(transport);
+        return new ConnectorService.Client(protocol);
+    }
+
+    public static ConnectorService.Client createSocketClient(String host, int port, boolean useSSL) throws TTransportException {
+        TTransport transport;
+        if (useSSL) {
+            TSSLTransportFactory.TSSLTransportParameters params = new TSSLTransportFactory.TSSLTransportParameters();
+            params.setTrustStore(System.getProperty("ssl.truststore"), System.getProperty("ssl.truststore.password"));
+            transport = TSSLTransportFactory.getClientSocket(host, port, 0, params);
+        } else {
+            transport = new TSocket(host, port);
+        }
+        TProtocol protocol = new TCompactProtocol.Factory().getProtocol(transport);
+        ConnectorService.Client client = new ConnectorService.Client(protocol);
+        if (!transport.isOpen()) {
+            transport.open();
+        }
+        return client;
+    }
 
     public static Long getInteger(Field value) {
         return value.isIsNull() ? null : Long.parseLong(value.getValue());
@@ -31,6 +69,19 @@ public final class ThriftUtils {
 
     public static DateTime getDateTime(Field value) {
         return value.isIsNull() ? null : DATE_TIME_FORMATTER.parseDateTime(value.getValue());
+    }
+
+    public static FieldType detectType(Object value) {
+        if (value instanceof Short || value instanceof Integer || value instanceof Long) {
+            return FieldType.INTEGER;
+        }
+        if (value instanceof Number) {
+            return FieldType.DOUBLE;
+        }
+        if (value instanceof Date) {
+            return FieldType.DATE;
+        }
+        return FieldType.STRING;
     }
 
     public static CollectionInfo getCollectionInfo(String schema, String tableName) {

--- a/src/main/java/com/zoomdata/connector/example/common/utils/metadatabuilders/Filters.java
+++ b/src/main/java/com/zoomdata/connector/example/common/utils/metadatabuilders/Filters.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.common.utils.metadatabuilders;
 
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.zoomdata.gen.edc.filter.FilterFunction.*;
+import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
@@ -118,102 +119,102 @@ public class Filters {
 
     public static Filter ge(String field, String value, FieldType type) {
         return new Filter(FilterFunction.GE)
-            .setFilterGE(new FilterGE()
-                    .setPath(field)
-                    .setType(type)
-                    .setValue(new Field().setValue(value))
-            );
+                .setFilterGE(new FilterGE()
+                        .setPath(field)
+                        .setType(type)
+                        .setValue(new Field().setValue(value))
+                );
     }
 
     public static Filter gt(String field, String value, FieldType type) {
         return new Filter(FilterFunction.GT)
-            .setFilterGT(new FilterGT()
-                    .setPath(field)
-                    .setType(type)
-                    .setValue(new Field().setValue(value))
-            );
+                .setFilterGT(new FilterGT()
+                        .setPath(field)
+                        .setType(type)
+                        .setValue(new Field().setValue(value))
+                );
     }
 
     public static Filter lt(String field, String value, FieldType type) {
         return new Filter(FilterFunction.LT)
-            .setFilterLT(new FilterLT()
-                    .setPath(field)
-                    .setType(type)
-                    .setValue(new Field().setValue(value))
-            );
+                .setFilterLT(new FilterLT()
+                        .setPath(field)
+                        .setType(type)
+                        .setValue(new Field().setValue(value))
+                );
     }
 
     public static Filter le(String field, String value, FieldType type) {
         return new Filter(FilterFunction.LE)
-            .setFilterLE(new FilterLE()
-                    .setPath(field)
-                    .setType(type)
-                    .setValue(new Field().setValue(value))
-            );
+                .setFilterLE(new FilterLE()
+                        .setPath(field)
+                        .setType(type)
+                        .setValue(new Field().setValue(value))
+                );
     }
 
     public static Filter eq(String field, String value, FieldType type) {
         return new Filter(FilterFunction.EQ)
-            .setFilterEQ(new FilterEQ()
-                    .setPath(field)
-                    .setType(type)
-                    .setValue(new Field().setValue(value))
-            );
+                .setFilterEQ(new FilterEQ()
+                        .setPath(field)
+                        .setType(type)
+                        .setValue(new Field().setValue(value))
+                );
     }
 
     public static Filter isNull(String field, FieldType type) {
         return new Filter(FilterFunction.IS_NULL)
-            .setFilterISNULL(new FilterISNULL()
-                    .setType(type)
-                    .setPath(field)
-            );
+                .setFilterISNULL(new FilterISNULL()
+                        .setType(type)
+                        .setPath(field)
+                );
     }
 
     public static Filter eqi(String field, String value) {
         return new Filter(FilterFunction.EQI)
-            .setFilterEQI(new FilterEQI()
-                    .setPath(field)
-                    .setValue(new Field().setValue(value))
-            );
+                .setFilterEQI(new FilterEQI()
+                        .setPath(field)
+                        .setValue(new Field().setValue(value))
+                );
     }
 
     public static Filter in(String field, FieldType type, String... values) {
         return new Filter(FilterFunction.IN)
-            .setFilterIN(new FilterIN()
-                .setPath(field)
-                .setType(type)
-                .setValues(stream(values)
-                    .map(v -> new Field().setValue(v))
-                    .collect(Collectors.toList())));
+                .setFilterIN(new FilterIN()
+                        .setPath(field)
+                        .setType(type)
+                        .setValues(stream(values)
+                                .map(v -> new Field().setValue(v))
+                                .collect(Collectors.toList())));
     }
 
     public static Filter contains(String field, String value) {
         return new Filter(FilterFunction.CONTAINS)
-            .setFilterCONTAINS(new FilterCONTAINS()
-                    .setPath(field)
-                    .setValue(new Field().setValue(value))
-            );
+                .setFilterCONTAINS(new FilterCONTAINS()
+                        .setPath(field)
+                        .setValue(new Field().setValue(value))
+                );
     }
 
     public static Filter textSearch(String field, String value) {
         return new Filter(FilterFunction.TEXT_SEARCH)
-            .setFilterTEXT_SEARCH(new FilterTEXT_SEARCH()
-                    .setPath(field)
-                    .setValue(value)
-            );
+                .setFilterTEXT_SEARCH(new FilterTEXT_SEARCH()
+                        .setPath(field)
+                        .setValue(value)
+                );
     }
 
     public static Filter textSearch(String value) {
         return new Filter(FilterFunction.TEXT_SEARCH)
-            .setFilterTEXT_SEARCH(new FilterTEXT_SEARCH()
-                    .setValue(value)
-            );
+                .setFilterTEXT_SEARCH(new FilterTEXT_SEARCH()
+                        .setValue(value)
+                );
     }
 
     public static Filter not(Filter filter) {
         return new Filter(FilterFunction.NOT)
-            .setFilterNOT(new FilterNOT()
-                .setFilter(filter));
+                .setFilterNOT(new FilterNOT()
+                        .setFilter(filter));
     }
 
     public static Filter or(Filter... subFilters) {
@@ -222,8 +223,8 @@ public class Filters {
 
     public static Filter or(List<Filter> subFilters) {
         return new Filter(FilterFunction.OR)
-            .setFilterOR(new FilterOR()
-                .setFilters(subFilters));
+                .setFilterOR(new FilterOR()
+                        .setFilters(subFilters));
     }
 
     public static Filter and(Filter... subFilters) {
@@ -232,8 +233,8 @@ public class Filters {
 
     public static Filter and(List<Filter> subFilters) {
         return new Filter(FilterFunction.AND)
-            .setFilterAND(new FilterAND()
-                .setFilters(subFilters));
+                .setFilterAND(new FilterAND()
+                        .setFilters(subFilters));
     }
 
     public static Filter newCompositeFilter(FilterFunction type, List<Filter> filters) {
@@ -245,7 +246,7 @@ public class Filters {
             case NOT:
                 return new Filter(NOT).setFilterNOT(new FilterNOT(filters.get(0)));
             default:
-                throw new IllegalArgumentException(String.format("Filter of type [%s] can't contain inner filters: %s", type, filters));
+                throw new IllegalArgumentException(format("Filter of type [%s] can't contain inner filters: %s", type, filters));
         }
     }
 

--- a/src/main/java/com/zoomdata/connector/example/common/utils/metadatabuilders/Groups.java
+++ b/src/main/java/com/zoomdata/connector/example/common/utils/metadatabuilders/Groups.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.common.utils.metadatabuilders;
+
+import com.zoomdata.gen.edc.group.AttributeGroup;
+import com.zoomdata.gen.edc.group.Group;
+import com.zoomdata.gen.edc.group.GroupType;
+import com.zoomdata.gen.edc.group.HistogramGroup;
+import com.zoomdata.gen.edc.group.TimeGroup;
+import com.zoomdata.gen.edc.types.TimeGranularity;
+
+public final class Groups {
+
+    private Groups() {
+    }
+
+    public static Group group(String field) {
+        return new Group(GroupType.ATTRIBUTE_GROUP)
+                .setAttributeGroup(new AttributeGroup()
+                        .setField(field));
+    }
+
+    public static Group timeGroup(String field, TimeGranularity granularity) {
+        return new Group(GroupType.TIME_GROUP).setTimeGroup(
+                new TimeGroup()
+                        .setGranularity(granularity)
+                        .setField(field));
+    }
+
+    public static Group histogram(String field, double bucketSize) {
+        return histogram(field, 0, 0, bucketSize);
+    }
+
+    public static Group histogram(String field, double start, double end, double bucketSize) {
+        return new Group(GroupType.HISTOGRAM_GROUP)
+                .setHistogramGroup(new HistogramGroup()
+                        .setField(field)
+                        .setBucketSize(bucketSize)
+                        .setStartPoint(start)
+                        .setEndPoint(end)
+                );
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/common/utils/metadatabuilders/ResponseInfoBuilder.java
+++ b/src/main/java/com/zoomdata/connector/example/common/utils/metadatabuilders/ResponseInfoBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.common.utils.metadatabuilders;
 

--- a/src/main/java/com/zoomdata/connector/example/common/utils/struct/Pair.java
+++ b/src/main/java/com/zoomdata/connector/example/common/utils/struct/Pair.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.common.utils.struct;
+
+public final class Pair<T1, T2> {
+    private final T1 left;
+    private final T2 right;
+
+    private Pair(T1 left, T2 right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    public static <A, B> Pair<A, B> create(A left, B right) {
+        return new Pair<>(left, right);
+    }
+
+    public T1 getLeft() {
+        return left;
+    }
+
+    public T2 getRight() {
+        return right;
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/ConnectorServerMain.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/ConnectorServerMain.java
@@ -1,9 +1,8 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework;
 
-import com.zoomdata.connector.example.framework.annotation.Connector;
 import com.zoomdata.connector.example.framework.provider.ConnectorBeanNameGenerator;
 import com.zoomdata.connector.example.framework.service.ZoomdataConnectorService;
 import com.zoomdata.gen.edc.ConnectorService;
@@ -13,7 +12,10 @@ import org.apache.thrift.server.TServlet;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.servlet.ServletRegistrationBean;
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
 
 /*
  * This example uses Spring Boot with embedded Jetty to quickly and easily provide a HTTP server for serving
@@ -24,7 +26,6 @@ import org.springframework.context.annotation.*;
 @Configuration
 @SpringBootApplication
 @ComponentScan(basePackages = "com.zoomdata",
-        includeFilters = {@ComponentScan.Filter(type = FilterType.ANNOTATION, value = Connector.class)},
         nameGenerator=ConnectorBeanNameGenerator.class)
 @PropertySource("classpath:framework.properties")
 public abstract class ConnectorServerMain {

--- a/src/main/java/com/zoomdata/connector/example/framework/annotation/Connector.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/annotation/Connector.java
@@ -1,7 +1,9 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.annotation;
+
+import org.springframework.stereotype.Component;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -11,6 +13,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
 @Target(TYPE)
+@Component
 public @interface Connector {
     String value();
 }

--- a/src/main/java/com/zoomdata/connector/example/framework/api/IDataProvider.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/api/IDataProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.api;
 
@@ -10,7 +10,7 @@ import com.zoomdata.gen.edc.request.serverdescription.ServerDescription;
  * DataSource related methods (connector)
  *
  * Provide implementation of this interface for specific datasource.
- * Implementation allows to use EDC based connectivity to new datasource from zoomdata.
+ * Implementation allows to use connector framework based connectivity to new datasource from Zoomdata.
  *
  */
 public interface IDataProvider {
@@ -65,3 +65,4 @@ public interface IDataProvider {
     void validateRequestInfo(RequestInfo requestInfo);
 
 }
+

--- a/src/main/java/com/zoomdata/connector/example/framework/api/IDescriptionProvider.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/api/IDescriptionProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.api;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/api/IFeatures.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/api/IFeatures.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.api;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/api/ITypesMapping.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/api/ITypesMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.api;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/async/AsyncException.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/async/AsyncException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.async;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/async/AsyncProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/async/AsyncProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.async;
 
@@ -31,11 +31,11 @@ public class AsyncProcessor {
             log.debug("Tasks count by provider " + simpleName + ": " + tasks.size());
 
             tasks.entrySet().stream()
-                .filter(e -> e.getValue().checkLostAndClose())
-                .map(Map.Entry::getKey)
-                .collect(toList())
-                .stream()
-                .forEach(tasks::remove);
+                    .filter(e -> e.getValue().checkLostAndClose())
+                    .map(Map.Entry::getKey)
+                    .collect(toList())
+                    .stream()
+                    .forEach(tasks::remove);
         }, 10, 10, TimeUnit.SECONDS);
     }
 

--- a/src/main/java/com/zoomdata/connector/example/framework/async/ComputeTaskHolder.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/async/ComputeTaskHolder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.async;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/async/Cursor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/async/Cursor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.async;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/async/IComputeTask.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/async/IComputeTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.async;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/async/IComputeTaskFactory.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/async/IComputeTaskFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.async;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/DelayedParameter.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/DelayedParameter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/IResultSetMapper.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/IResultSetMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/JdbcCommons.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/JdbcCommons.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/Meta.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/Meta.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/PropertiesExtractor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/PropertiesExtractor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/SQLConnectionPoolKey.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/SQLConnectionPoolKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/ThriftTypeFunction.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/ThriftTypeFunction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/op/BinaryOp.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/op/BinaryOp.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.op;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/op/UnaryOp.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/op/UnaryOp.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.op;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/AggSortsProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/AggSortsProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql;
 
@@ -21,23 +21,5 @@ public interface AggSortsProcessor {
      * @return list of {@link OrderSpecifier} for ORDER BY.
      */
     List<OrderSpecifier> process(Path<?> table, List<AggSort> sorts,
-                                 MetricsProcessor metricsProcessor, GroupsProcessor groupsProcessor);
-
-    /**
-     * Returns table.
-     * @return table or <code>null</code> if processor hasn't been initialized.
-     */
-    Path<?> getTable();
-
-    /**
-     * Returns list of processed sorts.
-     * @return list of sorts or <code>null</code> if processor hasn't been initialized.
-     */
-    List<AggSort> getThriftAggSorts();
-
-    /**
-     * Returns result of {@link #process(Path, List, MetricsProcessor, GroupsProcessor)} method execution.
-     * @return list of {@link OrderSpecifier} or <code>null</code> if processor hasn't been initialized.
-     */
-    List<OrderSpecifier> getOrderBy();
+                                 MetricsProcessor metricsProcessor, IGroupExpressionProducer groupsProcessor);
 }

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/FieldsProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/FieldsProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/FiltersProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/FiltersProcessor.java
@@ -1,9 +1,8 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql;
 
-import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
 import com.zoomdata.gen.edc.filter.Filter;
 
@@ -12,26 +11,13 @@ import java.util.List;
 public interface FiltersProcessor {
     /**
      * Initializes processor and does all work.
-     * @param table table.
      * @param filters filters.
      * @return predicate for WHERE.
      */
-    Predicate process(Path<?> table, List<Filter> filters);
+    Predicate process(List<Filter> filters);
 
     /**
-     * Returns table.
-     * @return table or <code>null</code> if processor hasn't been initialized.
-     */
-    Path<?> getTable();
-
-    /**
-     * Returns list of processed filters.
-     * @return list of filters or <code>null</code> if processor hasn't been initialized.
-     */
-    List<Filter> getThriftFilters();
-
-    /**
-     * Returns result of {@link #process(Path, List)} method execution.
+     * Returns result of {@link #process(List)} method execution.
      * @return WHERE predicate or <code>null</code> if processor hasn't been initialized.
      */
     Predicate getWhere();

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/GroupsProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/GroupsProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/IAliasGenerator.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/IAliasGenerator.java
@@ -1,0 +1,10 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql;
+
+public interface IAliasGenerator {
+    String generate(String fieldName);
+    String generateForPercentiles(String fieldName);
+}
+

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/IGroupExpressionProducer.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/IGroupExpressionProducer.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql;
+
+import com.querydsl.core.types.Path;
+import com.zoomdata.connector.example.framework.common.sql.impl.AliasedComparableExpressionBase;
+import com.zoomdata.gen.edc.group.Group;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+
+import java.util.List;
+import java.util.Map;
+
+public interface IGroupExpressionProducer {
+    /**
+     * Initializes processor and does all work.
+     * @param table table.
+     * @param groups groups.
+     * @param fieldMetadata
+     * @return initialized processor.
+     */
+
+    // TODO construction logic details should be separated from the interface
+    IGroupExpressionProducer process(
+            Path<?> table,
+            List<Group> groups,
+            Map<String, FieldMetadata> fieldMetadata
+    );
+
+    /**
+     * Returns list of processed groups.
+     * @return list of groups or <code>null</code> if processor hasn't been initialized.
+     */
+    List<Group> getThriftGroups();
+
+    /**
+     * Returns result of {@link #process(Path, List, Map)} method execution, which is modified
+     * for select clause
+     * @return list of expressions or <code>null</code> if processor hasn't been initialized.
+     */
+    List<AliasedComparableExpressionBase> getExpressionsForSelect();
+
+    /**
+     * Returns result of {@link #process(Path, List, Map)} method execution, which is modified
+     * for group by clause
+     * @return list of expressions or <code>null</code> if processor hasn't been initialized.
+     */
+    List<AliasedComparableExpressionBase> getExpressionsForGroupBy();
+
+    /**
+     * Returns GROUP BY expression by processed group. Intended for order by clause.
+     * @return expression or <code>null</code> if processor hasn't been initialized or
+     * there is no expression for this group.
+     */
+    AliasedComparableExpressionBase getExpressionForOrderBy(Group group);
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/MetricsProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/MetricsProcessor.java
@@ -1,15 +1,15 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql;
 
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
 import com.querydsl.sql.SQLQuery;
+import com.zoomdata.gen.edc.filter.Filter;
 import com.zoomdata.gen.edc.metric.Metric;
 
 import java.util.List;
-
 
 public interface MetricsProcessor {
     /**
@@ -26,13 +26,13 @@ public interface MetricsProcessor {
      * @param sqlQueryBuilder SQLQueryBuilder. May be used to create processors required by subqueries using its
      *                        factory methods.
      * @param sqlQuery main query.
-     * @param filtersProcessor filter processor used in main query. May be used to get filters in case when filtering
-     *                         in subquery must be the same as in main query.
+     * @param thriftFilters may be used to as filters in case when filtering in subquery
+     *                      must be the same as in main query.
      * @param groupsProcessor groups processor used in main query. May be used to get groups in case when grouping
      *                         in subquery must be the same as in main query.
      */
     void doJoins(SQLQueryBuilder sqlQueryBuilder, SQLQuery sqlQuery,
-                 FiltersProcessor filtersProcessor, GroupsProcessor groupsProcessor);
+                 List<Filter> thriftFilters, IGroupExpressionProducer groupsProcessor);
 
     /**
      * Returns table.
@@ -58,4 +58,11 @@ public interface MetricsProcessor {
      * there is no expression for this metric.
      */
     ComparableExpressionBase getMetricExpression(Metric metric);
+
+    /**
+     * Returns alias to use for row number in percentile subquery
+     * @param percentileField
+     * @return
+     */
+    String createPercentileRowNumberAliasName(String percentileField);
 }

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/ParametrizedQuery.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/ParametrizedQuery.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/RawSortsProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/RawSortsProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/SQLQueryBuilder.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/SQLQueryBuilder.java
@@ -1,8 +1,9 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql;
 
+import com.querydsl.core.types.Path;
 import com.querydsl.sql.SQLTemplates;
 import com.zoomdata.gen.edc.filter.Filter;
 import com.zoomdata.gen.edc.group.Group;
@@ -70,9 +71,9 @@ public interface SQLQueryBuilder {
 
     StatsProcessor createStatsProcessor();
 
-    FiltersProcessor createFiltersProcessor();
+    FiltersProcessor createFiltersProcessor(Path<?> table);
 
-    GroupsProcessor createGroupsProcessor();
+    IGroupExpressionProducer createGroupsProcessor();
 
     RawSortsProcessor createRawSortsProcessor();
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/StatsProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/StatsProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/StructuredToSQLTransformer.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/StructuredToSQLTransformer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/dialects/ExtendedMySQLTemplates.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/dialects/ExtendedMySQLTemplates.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.dialects;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/AbstractFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/AbstractFilterProcessor.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import com.zoomdata.gen.edc.types.FieldType;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public abstract class AbstractFilterProcessor implements FilterProcessor {
+
+    private Map<FieldType, Function<Filter, Predicate>> typedOperators = new HashMap<>();
+    {
+        typedOperators.put(FieldType.INTEGER, this::processIntegerFilter);
+        typedOperators.put(FieldType.DOUBLE, this::processDoubleFilter);
+        typedOperators.put(FieldType.STRING, this::processStringFilter);
+        typedOperators.put(FieldType.DATE, this::processDateFilter);
+    }
+
+    private Path<?> table;
+    private Map<String, FieldMetadata> metadata;
+    private FilterTypeService filterTypeService;
+
+    public AbstractFilterProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                                   FilterTypeService filterTypeService) {
+        this.table = table;
+        this.metadata = metadata;
+        this.filterTypeService = filterTypeService;
+    }
+
+    @Override
+    public Predicate processFilter(Filter filter) {
+        return typedOperators.get(extractFieldType(filter)).apply(filter);
+    }
+
+    protected abstract Predicate processIntegerFilter(Filter filter);
+
+    protected abstract Predicate processDoubleFilter(Filter filter);
+
+    protected abstract Predicate processStringFilter(Filter filter);
+
+    protected abstract Predicate processDateFilter(Filter filter);
+
+    protected abstract FieldType extractFieldType(Filter filter);
+
+    protected FieldMetadata getFieldMetadata(String fieldName){
+        return metadata.get(fieldName);
+    }
+
+    protected Path<?> getTable() {
+        return table;
+    }
+
+    protected FilterTypeService getFilterTypeService() {
+        return filterTypeService;
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/AndFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/AndFilterProcessor.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Predicate;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.filter.FilterAND;
+
+public class AndFilterProcessor implements FilterProcessor {
+
+    private FilterProcessor filtersProcessorRouter;
+
+    public AndFilterProcessor(FilterProcessor filtersProcessorRouter) {
+        this.filtersProcessorRouter = filtersProcessorRouter;
+    }
+
+    @Override
+    public Predicate processFilter(Filter filter) {
+        FilterAND filterAND = filter.getFilterAND();
+        Predicate[] subfilters = filterAND.getFilters().stream()
+            .map(subfilter -> filtersProcessorRouter.processFilter(subfilter))
+            .toArray(Predicate[]::new);
+        return ExpressionUtils.allOf(subfilters);
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/BinaryFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/BinaryFilterProcessor.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+
+import java.util.Map;
+
+import static com.querydsl.core.types.dsl.Expressions.constant;
+
+public abstract class BinaryFilterProcessor extends AbstractFilterProcessor {
+
+    public BinaryFilterProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                                 FilterTypeService filterTypeService) {
+        super(table, metadata, filterTypeService);
+    }
+
+    @Override
+    protected Predicate processIntegerFilter(Filter filter) {
+        String path = extractPath(filter);
+        FieldMetadata fieldMetadata = getFieldMetadata(path);
+        NumberPath numberPath = getFilterTypeService().getIntegerTypeResolver()
+            .buildPath(getTable(), path, fieldMetadata);
+        Expression constant = constant(getFilterTypeService().getIntegerTypeResolver()
+            .extract(extractValue(filter), fieldMetadata));
+        return processInteger(numberPath, constant);
+    }
+
+    @Override
+    protected Predicate processDoubleFilter(Filter filter) {
+        String path = extractPath(filter);
+        FieldMetadata fieldMetadata = getFieldMetadata(path);
+        NumberPath numberPath = getFilterTypeService().getDoubleTypeResolver()
+            .buildPath(getTable(), path, fieldMetadata);
+        Expression constant = constant(getFilterTypeService().getDoubleTypeResolver()
+            .extract(extractValue(filter), fieldMetadata));
+        return processDouble(numberPath, constant);
+    }
+
+    @Override
+    protected Predicate processStringFilter(Filter filter) {
+        String path = extractPath(filter);
+        FieldMetadata fieldMetadata = getFieldMetadata(path);
+        StringPath stringPath = getFilterTypeService().getStringTypeResolver()
+            .buildPath(getTable(), path, fieldMetadata);
+            Expression constant = constant(getFilterTypeService().getStringTypeResolver()
+                .extract(extractValue(filter), fieldMetadata));
+        return processString(stringPath, constant);
+    }
+
+    @Override
+    protected Predicate processDateFilter(Filter filter) {
+        String path = extractPath(filter);
+        FieldMetadata fieldMetadata = getFieldMetadata(path);
+        DateTimePath dateTimePath = getFilterTypeService().getDateTypeResolver()
+            .buildPath(getTable(), path, fieldMetadata);
+        Expression constant = constant(getFilterTypeService().getDateTypeResolver()
+            .extract(extractValue(filter), fieldMetadata));
+        return processDate(dateTimePath, constant);
+    }
+
+    protected abstract String extractPath(Filter filter);
+    protected abstract Field extractValue(Filter filter);
+
+    protected abstract BooleanExpression processInteger(NumberPath numberPath, Expression expression);
+    protected abstract BooleanExpression processDouble(NumberPath numberPath, Expression expression);
+    protected abstract BooleanExpression processString(StringPath stringPath, Expression expression);
+    protected abstract BooleanExpression processDate(DateTimePath dateTimePath, Expression expression);
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/ContainsFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/ContainsFilterProcessor.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import com.zoomdata.gen.edc.types.FieldType;
+
+import java.util.Map;
+
+public class ContainsFilterProcessor extends BinaryFilterProcessor {
+
+    public ContainsFilterProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                                   FilterTypeService filterTypeService) {
+        super(table, metadata, filterTypeService);
+    }
+
+    @Override
+    protected FieldType extractFieldType(Filter filter) {
+        return FieldType.STRING;
+    }
+
+    @Override
+    protected String extractPath(Filter filter) {
+        return filter.getFilterCONTAINS().getPath();
+    }
+
+    @Override
+    protected Field extractValue(Filter filter) {
+        return filter.getFilterCONTAINS().getValue();
+    }
+
+    @Override
+    protected BooleanExpression processInteger(NumberPath numberPath, Expression expression) {
+        throw new UnsupportedOperationException("Contains filter does not support integer type");
+    }
+
+    @Override
+    protected BooleanExpression processDouble(NumberPath numberPath, Expression expression) {
+        throw new UnsupportedOperationException("Contains filter does not support double type");
+    }
+
+    @Override
+    protected BooleanExpression processString(StringPath stringPath, Expression expression) {
+        return stringPath.like(expression);
+    }
+
+    @Override
+    protected BooleanExpression processDate(DateTimePath dateTimePath, Expression expression) {
+        throw new UnsupportedOperationException("Contains filter does not support date type");
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/EqFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/EqFilterProcessor.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import com.zoomdata.gen.edc.types.FieldType;
+
+import java.util.Map;
+
+public class EqFilterProcessor extends BinaryFilterProcessor {
+
+    public EqFilterProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                             FilterTypeService filterTypeService) {
+        super(table, metadata, filterTypeService);
+    }
+
+    @Override
+    protected FieldType extractFieldType(Filter filter) {
+        return filter.getFilterEQ().getType();
+    }
+
+    @Override
+    protected String extractPath(Filter filter) {
+        return filter.getFilterEQ().getPath();
+    }
+
+    @Override
+    protected Field extractValue(Filter filter) {
+        return filter.getFilterEQ().getValue();
+    }
+
+    @Override
+    protected BooleanExpression processInteger(NumberPath numberPath, Expression expression) {
+        return numberPath.eq(expression);
+    }
+
+    @Override
+    protected BooleanExpression processDouble(NumberPath numberPath, Expression expression) {
+        return numberPath.eq(expression);
+    }
+
+    @Override
+    protected BooleanExpression processString(StringPath stringPath, Expression expression) {
+        return stringPath.eq(expression);
+    }
+
+    @Override
+    protected BooleanExpression processDate(DateTimePath dateTimePath, Expression expression) {
+        return dateTimePath.eq(expression);
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/EqiFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/EqiFilterProcessor.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import com.zoomdata.gen.edc.types.FieldType;
+
+import java.util.Map;
+
+public class EqiFilterProcessor extends BinaryFilterProcessor {
+
+    public EqiFilterProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                              FilterTypeService filterTypeService) {
+        super(table, metadata, filterTypeService);
+    }
+
+    @Override
+    protected FieldType extractFieldType(Filter filter) {
+        return FieldType.STRING;
+    }
+
+    @Override
+    protected String extractPath(Filter filter) {
+        return filter.getFilterEQI().getPath();
+    }
+
+    @Override
+    protected Field extractValue(Filter filter) {
+        return filter.getFilterEQI().getValue();
+    }
+
+    @Override
+    protected BooleanExpression processInteger(NumberPath numberPath, Expression expression) {
+        throw new UnsupportedOperationException("Eqi filter does not support integer type");
+    }
+
+    @Override
+    protected BooleanExpression processDouble(NumberPath numberPath, Expression expression) {
+        throw new UnsupportedOperationException("Eqi filter does not support double type");
+    }
+
+    @Override
+    protected BooleanExpression processString(StringPath stringPath, Expression expression) {
+        return stringPath.equalsIgnoreCase(expression);
+    }
+
+    @Override
+    protected BooleanExpression processDate(DateTimePath dateTimePath, Expression expression) {
+        throw new UnsupportedOperationException("Eqi filter does not support date type");
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/FilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/FilterProcessor.java
@@ -1,0 +1,13 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Predicate;
+import com.zoomdata.gen.edc.filter.Filter;
+
+public interface FilterProcessor {
+
+    Predicate processFilter(Filter filter);
+
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/GeFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/GeFilterProcessor.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import com.zoomdata.gen.edc.types.FieldType;
+
+import java.util.Map;
+
+public class GeFilterProcessor extends BinaryFilterProcessor {
+
+
+    public GeFilterProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                             FilterTypeService filterTypeService) {
+        super(table, metadata, filterTypeService);
+    }
+
+    @Override
+    protected FieldType extractFieldType(Filter filter) {
+        return filter.getFilterGE().getType();
+    }
+
+    @Override
+    protected String extractPath(Filter filter) {
+        return filter.getFilterGE().getPath();
+    }
+
+    @Override
+    protected Field extractValue(Filter filter) {
+        return filter.getFilterGE().getValue();
+    }
+
+    @Override
+    protected BooleanExpression processInteger(NumberPath numberPath, Expression expression) {
+        return numberPath.goe(expression);
+    }
+
+    @Override
+    protected BooleanExpression processDouble(NumberPath numberPath, Expression expression) {
+        return numberPath.goe(expression);
+    }
+
+    @Override
+    protected BooleanExpression processString(StringPath stringPath, Expression expression) {
+        return stringPath.goe(expression);
+    }
+
+    @Override
+    protected BooleanExpression processDate(DateTimePath dateTimePath, Expression expression) {
+        return dateTimePath.goe(expression);
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/GtFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/GtFilterProcessor.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import com.zoomdata.gen.edc.types.FieldType;
+
+import java.util.Map;
+
+public class GtFilterProcessor extends BinaryFilterProcessor {
+
+    public GtFilterProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                             FilterTypeService filterTypeService) {
+        super(table, metadata, filterTypeService);
+    }
+
+    @Override
+    protected FieldType extractFieldType(Filter filter) {
+        return filter.getFilterGT().getType();
+    }
+
+    @Override
+    protected String extractPath(Filter filter) {
+        return filter.getFilterGT().getPath();
+    }
+
+    @Override
+    protected Field extractValue(Filter filter) {
+        return filter.getFilterGT().getValue();
+    }
+
+    @Override
+    protected BooleanExpression processInteger(NumberPath numberPath, Expression expression) {
+        return numberPath.gt(expression);
+    }
+
+    @Override
+    protected BooleanExpression processDouble(NumberPath numberPath, Expression expression) {
+        return numberPath.gt(expression);
+    }
+
+    @Override
+    protected BooleanExpression processString(StringPath stringPath, Expression expression) {
+        return stringPath.gt(expression);
+    }
+
+    @Override
+    protected BooleanExpression processDate(DateTimePath dateTimePath, Expression expression) {
+        return dateTimePath.gt(expression);
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/InFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/InFilterProcessor.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import com.zoomdata.gen.edc.types.FieldType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class InFilterProcessor extends VararyFilterProcessor {
+
+    public InFilterProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                             FilterTypeService filterTypeService) {
+        super(table, metadata, filterTypeService);
+    }
+
+    @Override
+    protected FieldType extractFieldType(Filter filter) {
+        return filter.getFilterIN().getType();
+    }
+
+    @Override
+    protected String extractPath(Filter filter) {
+        return filter.getFilterIN().getPath();
+    }
+
+    @Override
+    protected List<Field> extractValues(Filter filter) {
+        return filter.getFilterIN().getValues();
+    }
+
+    @Override
+    protected BooleanExpression processInteger(NumberPath numberPath, List<Object> values) {
+        return numberPath.in(values);
+    }
+
+    @Override
+    protected BooleanExpression processDouble(NumberPath numberPath, List<Object> values) {
+        return numberPath.in(values);
+    }
+
+    @Override
+    protected BooleanExpression processString(StringPath stringPath, List<Object> values) {
+        return stringPath.in(values.stream().map(Object::toString).collect(Collectors.toList()));
+    }
+
+    @Override
+    protected BooleanExpression processDate(DateTimePath dateTimePath, List<Object> values) {
+        return dateTimePath.in(values);
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/IsNullFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/IsNullFilterProcessor.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import com.zoomdata.gen.edc.types.FieldType;
+
+import java.util.Map;
+
+public class IsNullFilterProcessor extends UnaryFilterProcessor {
+
+    public IsNullFilterProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                                 FilterTypeService filterTypeService) {
+        super(table, metadata, filterTypeService);
+    }
+
+    @Override
+    protected FieldType extractFieldType(Filter filter) {
+        return filter.getFilterISNULL().getType();
+    }
+
+    @Override
+    protected String extractPath(Filter filter) {
+        return filter.getFilterISNULL().getPath();
+    }
+
+    @Override
+    protected BooleanExpression processInteger(NumberPath numberPath) {
+        return numberPath.isNull();
+    }
+
+    @Override
+    protected BooleanExpression processDouble(NumberPath numberPath) {
+        return numberPath.isNull();
+    }
+
+    @Override
+    protected BooleanExpression processString(StringPath stringPath) {
+        return stringPath.isNull();
+    }
+
+    @Override
+    protected BooleanExpression processDate(DateTimePath dateTimePath) {
+        return dateTimePath.isNull();
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/LeFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/LeFilterProcessor.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import com.zoomdata.gen.edc.types.FieldType;
+
+import java.util.Map;
+
+public class LeFilterProcessor extends BinaryFilterProcessor {
+
+    public LeFilterProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                             FilterTypeService filterTypeService) {
+        super(table, metadata, filterTypeService);
+    }
+
+    @Override
+    protected FieldType extractFieldType(Filter filter) {
+        return filter.getFilterLE().getType();
+    }
+
+    @Override
+    protected String extractPath(Filter filter) {
+        return filter.getFilterLE().getPath();
+    }
+
+    @Override
+    protected Field extractValue(Filter filter) {
+        return filter.getFilterLE().getValue();
+    }
+
+    @Override
+    protected BooleanExpression processInteger(NumberPath numberPath, Expression expression) {
+        return numberPath.loe(expression);
+    }
+
+    @Override
+    protected BooleanExpression processDouble(NumberPath numberPath, Expression expression) {
+        return numberPath.loe(expression);
+    }
+
+    @Override
+    protected BooleanExpression processString(StringPath stringPath, Expression expression) {
+        return stringPath.loe(expression);
+    }
+
+    @Override
+    protected BooleanExpression processDate(DateTimePath dateTimePath, Expression expression) {
+        return dateTimePath.loe(expression);
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/LtFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/LtFilterProcessor.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import com.zoomdata.gen.edc.types.FieldType;
+
+import java.util.Map;
+
+public class LtFilterProcessor extends BinaryFilterProcessor {
+
+    public LtFilterProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                             FilterTypeService filterTypeService) {
+        super(table, metadata, filterTypeService);
+    }
+
+    @Override
+    protected FieldType extractFieldType(Filter filter) {
+        return filter.getFilterLT().getType();
+    }
+
+    @Override
+    protected String extractPath(Filter filter) {
+        return filter.getFilterLT().getPath();
+    }
+
+    @Override
+    protected Field extractValue(Filter filter) {
+        return filter.getFilterLT().getValue();
+    }
+
+    @Override
+    protected BooleanExpression processInteger(NumberPath numberPath, Expression expression) {
+        return numberPath.lt(expression);
+    }
+
+    @Override
+    protected BooleanExpression processDouble(NumberPath numberPath, Expression expression) {
+        return numberPath.lt(expression);
+    }
+
+    @Override
+    protected BooleanExpression processString(StringPath stringPath, Expression expression) {
+        return stringPath.lt(expression);
+    }
+
+    @Override
+    protected BooleanExpression processDate(DateTimePath dateTimePath, Expression expression) {
+        return dateTimePath.lt(expression);
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/NotFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/NotFilterProcessor.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Predicate;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.filter.FilterNOT;
+
+public class NotFilterProcessor implements FilterProcessor {
+
+    private FilterProcessor filtersProcessorRouter;
+
+    public NotFilterProcessor(FilterProcessor filtersProcessorRouter) {
+        this.filtersProcessorRouter = filtersProcessorRouter;
+    }
+
+    @Override
+    public Predicate processFilter(Filter filter) {
+        FilterNOT filterNOT = filter.getFilterNOT();
+        Filter filterForNot = filterNOT.getFilter();;
+        return filtersProcessorRouter.processFilter(filterForNot).not();
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/OrFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/OrFilterProcessor.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.ExpressionUtils;
+import com.querydsl.core.types.Predicate;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.filter.FilterOR;
+
+public class OrFilterProcessor implements FilterProcessor {
+
+    private FilterProcessor filtersProcessorRouter;
+
+    public OrFilterProcessor(FilterProcessor filtersProcessorRouter) {
+        this.filtersProcessorRouter = filtersProcessorRouter;
+    }
+
+    @Override
+    public Predicate processFilter(Filter filter) {
+        FilterOR filterOR = filter.getFilterOR();
+        Predicate[] subfilters = filterOR.getFilters().stream()
+            .map(subfilter -> filtersProcessorRouter.processFilter(subfilter))
+            .toArray(Predicate[]::new);
+
+        return ExpressionUtils.anyOf(subfilters);
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/UnaryFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/UnaryFilterProcessor.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import com.zoomdata.gen.edc.types.FieldType;
+
+import java.util.Map;
+
+public abstract class UnaryFilterProcessor extends AbstractFilterProcessor {
+
+    public UnaryFilterProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                                FilterTypeService filterTypeService) {
+        super(table, metadata, filterTypeService);
+    }
+
+    @Override
+    protected BooleanExpression processIntegerFilter(Filter filter) {
+        String path = extractPath(filter);
+        FieldMetadata fieldMetadata = getFieldMetadata(path);
+        NumberPath numberPath = getFilterTypeService().getIntegerTypeResolver()
+            .buildPath(getTable(), path, fieldMetadata);
+        return processInteger(numberPath);
+    }
+
+    @Override
+    protected BooleanExpression processDoubleFilter(Filter filter) {
+        String path = extractPath(filter);
+        FieldMetadata fieldMetadata = getFieldMetadata(path);
+        NumberPath numberPath = getFilterTypeService().getDoubleTypeResolver()
+            .buildPath(getTable(), path, fieldMetadata);
+        return processDouble(numberPath);
+    }
+
+    @Override
+    protected BooleanExpression processStringFilter(Filter filter) {
+        String path = extractPath(filter);
+        FieldMetadata fieldMetadata = getFieldMetadata(path);
+        StringPath stringPath = getFilterTypeService().getStringTypeResolver()
+            .buildPath(getTable(), path, fieldMetadata);
+        return processString(stringPath);
+    }
+
+    @Override
+    protected BooleanExpression processDateFilter(Filter filter) {
+        String path = extractPath(filter);
+        FieldMetadata fieldMetadata = getFieldMetadata(path);
+        DateTimePath dateTimePath = getFilterTypeService().getDateTypeResolver()
+            .buildPath(getTable(), path, fieldMetadata);
+        return processDate(dateTimePath);
+    }
+
+    protected abstract FieldType extractFieldType(Filter filter);
+    protected abstract String extractPath(Filter filter);
+
+    protected abstract BooleanExpression processInteger(NumberPath numberPath);
+    protected abstract BooleanExpression processDouble(NumberPath numberPath);
+    protected abstract BooleanExpression processString(StringPath stringPath);
+    protected abstract BooleanExpression processDate(DateTimePath dateTimePath);
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/VararyFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/VararyFilterProcessor.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter;
+
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public abstract class VararyFilterProcessor extends AbstractFilterProcessor {
+
+    public VararyFilterProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                                 FilterTypeService filterTypeService) {
+        super(table, metadata, filterTypeService);
+    }
+
+    @Override
+    protected BooleanExpression processIntegerFilter(Filter filter) {
+        String path = extractPath(filter);
+        FieldMetadata fieldMetadata = getFieldMetadata(path);
+        NumberPath numberPath = getFilterTypeService().getIntegerTypeResolver()
+            .buildPath(getTable(), path, fieldMetadata);
+        List<Object> values = extractValues(filter).stream()
+            .map(field -> getFilterTypeService().getIntegerTypeResolver().extract(field, fieldMetadata))
+            .collect(Collectors.toList());
+        return processInteger(numberPath, values);
+    }
+
+    @Override
+    protected BooleanExpression processDoubleFilter(Filter filter) {
+        String path = extractPath(filter);
+        FieldMetadata fieldMetadata = getFieldMetadata(path);
+        NumberPath numberPath = getFilterTypeService().getDoubleTypeResolver()
+            .buildPath(getTable(), path, fieldMetadata);
+        List<Object> values = extractValues(filter).stream().map(field ->
+            getFilterTypeService().getDoubleTypeResolver().extract(field, fieldMetadata))
+            .collect(Collectors.toList());
+        return processDouble(numberPath, values);
+    }
+
+    @Override
+    protected BooleanExpression processStringFilter(Filter filter) {
+        String path = extractPath(filter);
+        FieldMetadata fieldMetadata = getFieldMetadata(path);
+        StringPath stringPath = getFilterTypeService().getStringTypeResolver()
+            .buildPath(getTable(), path, fieldMetadata);
+        List<Object> values = extractValues(filter).stream().map(field ->
+            getFilterTypeService().getStringTypeResolver().extract(field, fieldMetadata))
+            .collect(Collectors.toList());
+        return processString(stringPath, values);
+    }
+
+    @Override
+    protected BooleanExpression processDateFilter(Filter filter) {
+        String path = extractPath(filter);
+        FieldMetadata fieldMetadata = getFieldMetadata(path);
+        DateTimePath dateTimePath = getFilterTypeService().getDateTypeResolver()
+            .buildPath(getTable(), path, fieldMetadata);
+        List<Object> values = extractValues(filter).stream().map(field ->
+            getFilterTypeService().getDateTypeResolver().extract(field, fieldMetadata))
+            .collect(Collectors.toList());
+        return processDate(dateTimePath, values);
+    }
+
+    protected abstract String extractPath(Filter filter);
+    protected abstract List<Field> extractValues(Filter filter);
+
+    protected abstract BooleanExpression processInteger(NumberPath numberPath, List<Object> values);
+    protected abstract BooleanExpression processDouble(NumberPath numberPath, List<Object> values);
+    protected abstract BooleanExpression processString(StringPath stringPath, List<Object> values);
+    protected abstract BooleanExpression processDate(DateTimePath dateTimePath, List<Object> values);
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/DateFilterTypeResolver.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/DateFilterTypeResolver.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter.type;
+
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.Expressions;
+import com.zoomdata.connector.example.common.utils.ThriftUtils;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import org.joda.time.DateTime;
+
+public class DateFilterTypeResolver implements FilterTypeResolver<DateTime, DateTimePath<DateTime>> {
+
+    @Override
+    public DateTime extract(Field field, FieldMetadata fieldMetadata) {
+        return ThriftUtils.getDateTime(field);
+    }
+
+    @Override
+    public DateTimePath<DateTime> buildPath(Path<?> table, String path, FieldMetadata fieldMetadata) {
+        return Expressions.dateTimePath(DateTime.class, table, path);
+    }
+
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/DefaultFilterTypeService.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/DefaultFilterTypeService.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter.type;
+
+public class DefaultFilterTypeService implements FilterTypeService {
+
+    private final DoubleFilterTypeResolver doubleFilterTypeResolver = new DoubleFilterTypeResolver();
+    private final StringFilterTypeResolver stringFilterTypeResolver = new StringFilterTypeResolver();
+    private final DateFilterTypeResolver dateFilterTypeResolver = new DateFilterTypeResolver();
+    private IntegerFilterTypeResolver integerFilterTypeResolver = new IntegerFilterTypeResolver();
+
+    @Override
+    public FilterTypeResolver getIntegerTypeResolver() {
+        return integerFilterTypeResolver;
+    }
+
+    @Override
+    public FilterTypeResolver getDoubleTypeResolver() {
+        return doubleFilterTypeResolver;
+    }
+
+    @Override
+    public FilterTypeResolver getStringTypeResolver() {
+        return stringFilterTypeResolver;
+    }
+
+    @Override
+    public FilterTypeResolver getDateTypeResolver() {
+        return dateFilterTypeResolver;
+    }
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/DoubleFilterTypeResolver.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/DoubleFilterTypeResolver.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter.type;
+
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.zoomdata.connector.example.common.utils.ThriftUtils;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+
+public class DoubleFilterTypeResolver implements FilterTypeResolver<Double, NumberPath<Double>> {
+
+    @Override
+    public Double extract(Field field, FieldMetadata fieldMetadata) {
+        return ThriftUtils.getDouble(field);
+    }
+
+    @Override
+    public NumberPath<Double> buildPath(Path<?> table, String path, FieldMetadata fieldMetadata) {
+        return Expressions.numberPath(Double.class, table, path);
+    }
+
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/FilterTypeResolver.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/FilterTypeResolver.java
@@ -1,0 +1,15 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter.type;
+
+import com.querydsl.core.types.Path;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+
+public interface FilterTypeResolver<T, P extends Path<T>> {
+
+    T extract(Field field, FieldMetadata fieldMetadata);
+
+    P buildPath(Path<?> table, String path, FieldMetadata fieldMetadata);
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/FilterTypeService.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/FilterTypeService.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter.type;
+
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.StringPath;
+
+public interface FilterTypeService {
+
+    <T extends Number & Comparable<?>> FilterTypeResolver<T, NumberPath<T>> getIntegerTypeResolver();
+    <T extends Number & Comparable<?>> FilterTypeResolver<T, NumberPath<T>> getDoubleTypeResolver();
+    FilterTypeResolver<String, StringPath> getStringTypeResolver();
+    <T extends Comparable> FilterTypeResolver<T, DateTimePath<T>> getDateTypeResolver();
+
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/IntegerFilterTypeResolver.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/IntegerFilterTypeResolver.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter.type;
+
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.zoomdata.connector.example.common.utils.ThriftUtils;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+
+public class IntegerFilterTypeResolver implements FilterTypeResolver<Long, NumberPath<Long>> {
+
+    @Override
+    public Long extract(Field field, FieldMetadata fieldMetadata) {
+        return ThriftUtils.getInteger(field);
+    }
+
+    @Override
+    public NumberPath buildPath(Path<?> table, String path, FieldMetadata fieldMetadata) {
+        return Expressions.numberPath(Long.class, table, path);
+    }
+
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/StringFilterTypeResolver.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/filter/type/StringFilterTypeResolver.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.filter.type;
+
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringPath;
+import com.zoomdata.connector.example.common.utils.ThriftUtils;
+import com.zoomdata.gen.edc.types.Field;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+
+public class StringFilterTypeResolver implements FilterTypeResolver<String, StringPath> {
+
+    @Override
+    public String extract(Field field, FieldMetadata fieldMetadata) {
+        return ThriftUtils.getString(field);
+    }
+
+    @Override
+    public StringPath buildPath(Path<?> table, String path, FieldMetadata fieldMetadata) {
+        return Expressions.stringPath(table, path);
+    }
+
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/AliasGenerator.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/AliasGenerator.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.impl;
+
+import com.zoomdata.connector.example.framework.common.sql.IAliasGenerator;
+
+import javax.validation.constraints.NotNull;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class AliasGenerator implements IAliasGenerator {
+    private final Map<String, Integer> aliasCounts = new HashMap<>();
+
+    private static final int MAX_ALIAS_COUNT_PER_FIELD = 99_999;
+
+    private final Integer fieldPartLength;
+
+    private AliasGenerator(Builder builder) {
+        this.fieldPartLength = Optional.ofNullable(builder.maxAliasLength)
+                .map(length -> length - ("_" + MAX_ALIAS_COUNT_PER_FIELD).length())
+                .orElse(null);
+    }
+
+    public static Builder newAliasGenerator() {
+        return new Builder();
+    }
+
+    @Override
+    public String generate(String fieldName) {
+        String shortenedFieldName = shortenFieldNameForAlias(fieldName);
+        int counter = aliasCounts.getOrDefault(shortenedFieldName, 0);
+        aliasCounts.put(shortenedFieldName, increaseCounter(counter));
+        return shortenedFieldName + (counter > 0 ? "_" + counter : "");
+    }
+
+    @Override
+    public String generateForPercentiles(String fieldName) {
+        return shortenFieldNameForAlias(fieldName);
+    }
+
+    private int increaseCounter(int counter) {
+        if (fieldPartLength != null && counter >= MAX_ALIAS_COUNT_PER_FIELD) {
+            throw new UnsupportedOperationException(
+                    "Can't generate new aliases. Limit for field is exceeded: Limit=" + MAX_ALIAS_COUNT_PER_FIELD
+            );
+        }
+        return counter + 1;
+    }
+
+    private String shortenFieldNameForAlias(@NotNull String fieldName) {
+        return Optional.ofNullable(fieldPartLength).map(length ->
+                fieldName.substring(
+                        0,
+                        Math.min(
+                                fieldPartLength,
+                                fieldName.length())
+                )
+        ).orElse(fieldName);
+    }
+
+    public static final class Builder {
+        private Integer maxAliasLength;
+
+        private Builder() {
+        }
+
+        public AliasGenerator build() {
+            return new AliasGenerator(this);
+        }
+
+        public Builder maxAliasLength(Integer maxAliasLength) {
+            this.maxAliasLength = maxAliasLength;
+            return this;
+        }
+    }
+}
+

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/AliasedComparableExpressionBase.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/AliasedComparableExpressionBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.impl;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/AliasedSimpleExpression.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/AliasedSimpleExpression.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.impl;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultAggSortsProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultAggSortsProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.impl;
 
@@ -7,7 +7,7 @@ import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
 import com.zoomdata.connector.example.framework.common.sql.AggSortsProcessor;
-import com.zoomdata.connector.example.framework.common.sql.GroupsProcessor;
+import com.zoomdata.connector.example.framework.common.sql.IGroupExpressionProducer;
 import com.zoomdata.connector.example.framework.common.sql.MetricsProcessor;
 import com.zoomdata.gen.edc.group.Group;
 import com.zoomdata.gen.edc.metric.Metric;
@@ -18,7 +18,6 @@ import com.zoomdata.gen.edc.sort.SortType;
 import java.util.ArrayList;
 import java.util.List;
 
-
 public class DefaultAggSortsProcessor implements AggSortsProcessor {
     protected Path<?> table;
     protected List<AggSort> thriftAggSorts;
@@ -26,7 +25,7 @@ public class DefaultAggSortsProcessor implements AggSortsProcessor {
 
     @Override
     public List<OrderSpecifier> process(Path<?> table, List<AggSort> sorts,
-                                        MetricsProcessor metricsProcessor, GroupsProcessor groupsProcessor) {
+                                        MetricsProcessor metricsProcessor, IGroupExpressionProducer groupsProcessor) {
         this.table = table;
         this.thriftAggSorts = sorts;
 
@@ -38,7 +37,7 @@ public class DefaultAggSortsProcessor implements AggSortsProcessor {
             switch (type) {
                 case GROUP: {
                     Group g = s.getGroup();
-                    sortField = groupsProcessor.getGroupExpression(g);
+                    sortField = groupsProcessor.getExpressionForOrderBy(g);
                     if (sortField == null) {
                         throw new IllegalArgumentException("Group to sort on is unknown. Make sure that you " +
                                 "called withGroups(List<Group>) method with the group as parameter before this one.");
@@ -65,21 +64,6 @@ public class DefaultAggSortsProcessor implements AggSortsProcessor {
                 orderBy.add(sortField.asc());
             }
         }
-        return orderBy;
-    }
-
-    @Override
-    public Path<?> getTable() {
-        return table;
-    }
-
-    @Override
-    public List<AggSort> getThriftAggSorts() {
-        return thriftAggSorts;
-    }
-
-    @Override
-    public List<OrderSpecifier> getOrderBy() {
         return orderBy;
     }
 }

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultFieldsProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultFieldsProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.impl;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultFiltersProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultFiltersProcessor.java
@@ -1,47 +1,72 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.impl;
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
-import com.querydsl.core.types.dsl.DateTimeExpression;
-import com.querydsl.core.types.dsl.NumberExpression;
-import com.querydsl.core.types.dsl.StringExpression;
 import com.zoomdata.connector.example.framework.common.sql.FiltersProcessor;
-import com.zoomdata.gen.edc.filter.*;
-import com.zoomdata.gen.edc.types.FieldType;
+import com.zoomdata.connector.example.framework.common.sql.filter.AndFilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.ContainsFilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.EqFilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.EqiFilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.FilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.GeFilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.GtFilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.InFilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.IsNullFilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.LeFilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.LtFilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.NotFilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.OrFilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.filter.FilterFunction;
+import com.zoomdata.gen.edc.types.FieldMetadata;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
-public class DefaultFiltersProcessor implements FiltersProcessor {
-    protected Path<?> table;
-    protected List<Filter> thriftFilters;
-    protected BooleanBuilder where;
+public class DefaultFiltersProcessor implements FiltersProcessor, FilterProcessor {
+
+    private Path<?> table;
+    private Map<String, FieldMetadata> metadata;
+    private BooleanBuilder where = new BooleanBuilder();
+
+    private Map<FilterFunction, FilterProcessor> filterProcessors = new HashMap<>();
+
+    public DefaultFiltersProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                                   FilterTypeService filterTypeService) {
+        this.table = table;
+        this.metadata = metadata;
+        addFilterProcessor(FilterFunction.AND,  new AndFilterProcessor(this));
+        addFilterProcessor(FilterFunction.OR, new OrFilterProcessor(this));
+        addFilterProcessor(FilterFunction.NOT, new NotFilterProcessor(this));
+        addFilterProcessor(FilterFunction.EQ, new EqFilterProcessor(table, metadata, filterTypeService));
+        addFilterProcessor(FilterFunction.LT, new LtFilterProcessor(table, metadata, filterTypeService));
+        addFilterProcessor(FilterFunction.LE, new LeFilterProcessor(table, metadata, filterTypeService));
+        addFilterProcessor(FilterFunction.GT, new GtFilterProcessor(table, metadata, filterTypeService));
+        addFilterProcessor(FilterFunction.GE, new GeFilterProcessor(table, metadata, filterTypeService));
+        addFilterProcessor(FilterFunction.EQI, new EqiFilterProcessor(table, metadata, filterTypeService));
+        addFilterProcessor(FilterFunction.CONTAINS, new ContainsFilterProcessor(table, metadata, filterTypeService));
+        addFilterProcessor(FilterFunction.IS_NULL, new IsNullFilterProcessor(table, metadata, filterTypeService));
+        addFilterProcessor(FilterFunction.IN, new InFilterProcessor(table, metadata, filterTypeService));
+    }
+
+    protected void addFilterProcessor(FilterFunction filterFunction,
+                                      FilterProcessor filterProcessor) {
+        filterProcessors.put(filterFunction, filterProcessor);
+    }
 
     @Override
-    public Predicate process(Path<?> table, List<Filter> thriftFilters) {
-        this.table = table;
-        this.thriftFilters = thriftFilters;
-
-        where = new BooleanBuilder();
-        for (Filter filter : thriftFilters) {
-            processFilter(table, filter, where);
+    public Predicate process(List<Filter> filters) {
+        for (Filter filter : filters) {
+            where.and(processFilter(filter));
         }
         return where;
-    }
-
-    @Override
-    public Path<?> getTable() {
-        return table;
-    }
-
-    @Override
-    public List<Filter> getThriftFilters() {
-        return thriftFilters;
     }
 
     @Override
@@ -49,156 +74,8 @@ public class DefaultFiltersProcessor implements FiltersProcessor {
         return where;
     }
 
-    // ==================== FILTER IMPLEMENTATION ==========
-
-    protected Predicate processFilter(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        FilterFunction type = filter.getType();
-        switch (type) {
-            case AND: {
-                processAND(table, filter, predicate);
-                break;
-            }
-            case OR: {
-                processOR(table, filter, predicate);
-                break;
-            }
-            case NOT: {
-                processNOT(table, filter, predicate);
-                break;
-            }
-            case EQ: {
-                processEQ(table, filter, predicate);
-                break;
-            }
-
-            case LT: {
-                processLT(table, filter, predicate);
-                break;
-            }
-
-            case LE: {
-                processLE(table, filter, predicate);
-                break;
-            }
-
-            case GT: {
-                processGT(table, filter, predicate);
-                break;
-            }
-
-            case GE: {
-                processGE(table, filter, predicate);
-                break;
-            }
-
-            case EQI: {
-                processEQI(table, filter, predicate);
-                break;
-            }
-
-            case CONTAINS: {
-                processCONTAINS(table, filter, predicate);
-                break;
-            }
-
-            case IS_NULL: {
-                processIS_NULL(table, filter, predicate);
-                break;
-            }
-
-            case TEXT_SEARCH: {
-                processTEXT_SEARCH(table, filter, predicate);
-                break;
-            }
-
-            case IN: {
-                processIN(table, filter, predicate);
-                break;
-            }
-        }
-        return predicate;
-    }
-
-    protected void processAND(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        FilterAND filterAND = filter.getFilterAND();
-        Predicate[] subfilters = filterAND.getFilters().stream()
-            .map(subfilter -> processFilter(table, subfilter, new BooleanBuilder()))
-            .toArray(Predicate[]::new);
-
-        predicate.and(ExpressionUtils.allOf(subfilters));
-    }
-
-    protected void processOR(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        FilterOR filterOR = filter.getFilterOR();
-        Predicate[] subfilters = filterOR.getFilters().stream()
-            .map(subfilter -> processFilter(table, subfilter, new BooleanBuilder()))
-            .toArray(Predicate[]::new);
-
-        predicate.and(ExpressionUtils.anyOf(subfilters));
-    }
-
-    protected void processNOT(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        FilterNOT filterNOT = filter.getFilterNOT();
-        Filter filterForNot = filterNOT.getFilter();
-        predicate.andNot(processFilter(table, filterForNot, new BooleanBuilder()));
-    }
-
-    protected void processEQ(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        FilterEQ filterEQ = filter.getFilterEQ();
-        predicate.and(Utils.createPredicateBinary(table, filterEQ.getType(), filterEQ.getValue(), filterEQ.getPath(),
-                NumberExpression::eq, StringExpression::eq, DateTimeExpression::eq));
-    }
-
-    protected void processLT(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        FilterLT filterLT = filter.getFilterLT();
-        predicate.and(Utils.createPredicateBinary(table, filterLT.getType(), filterLT.getValue(), filterLT.getPath(),
-                NumberExpression::lt, StringExpression::lt, DateTimeExpression::lt));
-    }
-
-    protected void processLE(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        FilterLE filterLE = filter.getFilterLE();
-        predicate.and(Utils.createPredicateBinary(table, filterLE.getType(), filterLE.getValue(), filterLE.getPath(),
-                NumberExpression::loe, StringExpression::loe, DateTimeExpression::loe));
-    }
-
-    protected void processGT(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        FilterGT filterGT = filter.getFilterGT();
-        predicate.and(Utils.createPredicateBinary(table, filterGT.getType(), filterGT.getValue(), filterGT.getPath(),
-                NumberExpression::gt, StringExpression::gt, DateTimeExpression::gt));
-    }
-
-    protected void processGE(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        FilterGE filterGE = filter.getFilterGE();
-        predicate.and(Utils.createPredicateBinary(table, filterGE.getType(), filterGE.getValue(), filterGE.getPath(),
-                NumberExpression::goe, StringExpression::goe, DateTimeExpression::goe));
-    }
-
-    protected void processEQI(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        FilterEQI filterEQI = filter.getFilterEQI();
-        predicate.and(Utils.createPredicateBinary(table, FieldType.STRING, filterEQI.getValue(), filterEQI.getPath(),
-                null, StringExpression::equalsIgnoreCase, null));
-    }
-
-    protected void processCONTAINS(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        FilterCONTAINS filterCONTAINS = filter.getFilterCONTAINS();
-        predicate.and(Utils.createPredicateBinary(table, FieldType.STRING, filterCONTAINS.getValue(), filterCONTAINS.getPath(),
-                null, StringExpression::like, null));
-    }
-
-    protected void processIS_NULL(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        FilterISNULL filterISNULL = filter.getFilterISNULL();
-        predicate.and(Utils.createPredicateUnary(table, filterISNULL.getType(), filterISNULL.getPath(),
-                NumberExpression::isNull, StringExpression::isNull, DateTimeExpression::isNull));
-    }
-
-    protected void processTEXT_SEARCH(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        throw new UnsupportedOperationException("TEXT_SEARCH is not supported.");
-    }
-
-    protected void processIN(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        FilterIN filterIN = filter.getFilterIN();
-        //noinspection unchecked
-        predicate.and(Utils.createPredicateVarary(table, filterIN.getType(), filterIN.getPath(), filterIN.getValues(),
-                (nf, e) -> nf.in(e)));
+    @Override
+    public Predicate processFilter(Filter filter) {
+        return filterProcessors.get(filter.getType()).processFilter(filter);
     }
 }

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultGroupsProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultGroupsProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.impl;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultMetricsProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultMetricsProcessor.java
@@ -1,33 +1,57 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.impl;
 
+import com.google.common.base.Supplier;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.Path;
 import com.querydsl.core.types.Predicate;
-import com.querydsl.core.types.dsl.*;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.core.types.dsl.DateTimeExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberOperation;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.sql.SQLExpressions;
 import com.querydsl.sql.SQLQuery;
 import com.zoomdata.connector.example.common.utils.StringUtils;
-import com.zoomdata.connector.example.framework.common.sql.FiltersProcessor;
-import com.zoomdata.connector.example.framework.common.sql.GroupsProcessor;
+import com.zoomdata.connector.example.framework.common.sql.IAliasGenerator;
+import com.zoomdata.connector.example.framework.common.sql.IGroupExpressionProducer;
 import com.zoomdata.connector.example.framework.common.sql.MetricsProcessor;
 import com.zoomdata.connector.example.framework.common.sql.SQLQueryBuilder;
 import com.zoomdata.gen.edc.filter.Filter;
 import com.zoomdata.gen.edc.group.Group;
-import com.zoomdata.gen.edc.metric.*;
+import com.zoomdata.gen.edc.metric.Metric;
+import com.zoomdata.gen.edc.metric.MetricAvg;
+import com.zoomdata.gen.edc.metric.MetricCount;
+import com.zoomdata.gen.edc.metric.MetricDistinctCount;
+import com.zoomdata.gen.edc.metric.MetricLastValue;
+import com.zoomdata.gen.edc.metric.MetricMax;
+import com.zoomdata.gen.edc.metric.MetricMin;
+import com.zoomdata.gen.edc.metric.MetricPercentile;
+import com.zoomdata.gen.edc.metric.MetricSum;
 import com.zoomdata.gen.edc.types.FieldMetadata;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-import static com.querydsl.core.types.dsl.Expressions.*;
-import static com.zoomdata.connector.example.framework.common.sql.impl.Utils.createPercentileRowNumberAliasName;
-
-//import com.querydsl.core.types.dsl.*;
-
+import static com.querydsl.core.types.dsl.Expressions.cases;
+import static com.querydsl.core.types.dsl.Expressions.comparablePath;
+import static com.querydsl.core.types.dsl.Expressions.constant;
+import static com.querydsl.core.types.dsl.Expressions.dateTimePath;
+import static com.querydsl.core.types.dsl.Expressions.nullExpression;
+import static com.querydsl.core.types.dsl.Expressions.numberPath;
+import static com.querydsl.core.types.dsl.Expressions.stringPath;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
 
 public class DefaultMetricsProcessor implements MetricsProcessor {
 
@@ -41,84 +65,85 @@ public class DefaultMetricsProcessor implements MetricsProcessor {
     protected List<Metric> thriftMetrics;
     protected Map<Metric, ComparableExpressionBase> metricExpressions = new HashMap<>();
     protected Map<String, AliasedSimpleExpression<?>> lastValueTables;
-    protected Map<String, FieldMetadata> fieldMetadata = new HashMap<>();
+    protected Map<String, FieldMetadata> fieldMetadata;
 
+    // FIXME This collections contains the same data as in metricExpressions, so there is unreasonable data duplication
     List<ComparableExpressionBase> select;
 
     private AliasedSimpleExpression fromClause;
 
+    protected IAliasGenerator aliasGenerator;
+    private Supplier<AliasGenerator> aliasGeneratorSupplier = () -> AliasGenerator.newAliasGenerator().build();
+
     public DefaultMetricsProcessor() {
+        this(null);
     }
 
     public DefaultMetricsProcessor(Map<String, FieldMetadata> fieldMetadata) {
-        this.fieldMetadata = fieldMetadata;
+        this(fieldMetadata, null);
     }
 
     public DefaultMetricsProcessor(Map<String, FieldMetadata> fieldMetadata, AliasedSimpleExpression fromClause) {
-        this(fieldMetadata);
+        this.fieldMetadata = Optional.ofNullable(fieldMetadata).orElse(new HashMap<>());
         this.fromClause = fromClause;
+    }
+
+    public DefaultMetricsProcessor useAliasGeneratorSupplier(Supplier<AliasGenerator> supplier) {
+        this.aliasGeneratorSupplier = supplier;
+        return this;
     }
 
     @Override
     public List<ComparableExpressionBase> process(Path<?> table, List<Metric> metrics) {
+        aliasGenerator = aliasGeneratorSupplier.get();
         this.table = table;
         this.thriftMetrics = metrics;
-
         select = new ArrayList<>(metrics.size());
-
-        for (Metric m : metrics) {
-            MetricType type = m.getType();
-            ComparableExpressionBase e;
-            switch (type) {
-                case COUNT: {
-                    e = processCOUNT(m);
-                    break;
-                }
-                case MIN: {
-                    e = processMIN(m);
-                    break;
-                }
-                case MAX: {
-                    e = processMAX(m);
-                    break;
-                }
-                case AVG: {
-                    e = processAVG(m);
-                    break;
-                }
-                case SUM: {
-                    e = processSUM(m);
-                    break;
-                }
-                case DISTINCT_COUNT: {
-                    e = processDISTINCT_COUNT(m);
-                    break;
-                }
-                case LAST_VALUE: {
-                    e = processLAST_VALUE(m);
-                    break;
-                }
-                case PERCENTILES: {
-                    e = processPERCENTILES(m);
-                    break;
-                }
-                default: {
-                    throw new IllegalStateException("Metric of type " + type + " is not supported.");
-                }
-
-            }
-            select.add(e);
-            metricExpressions.put(m, e);
+        for (Metric metric : metrics) {
+            ComparableExpressionBase expression = process(metric);
+            select.add(expression);
+            metricExpressions.put(metric, expression);
         }
-
         return select;
+    }
+
+    ComparableExpressionBase process(Metric metric) {
+        switch (metric.getType()) {
+            case COUNT: {
+                return processCOUNT(metric);
+            }
+            case MIN: {
+                return processMIN(metric);
+            }
+            case MAX: {
+                return processMAX(metric);
+            }
+            case AVG: {
+                return processAVG(metric);
+            }
+            case SUM: {
+                return processSUM(metric);
+            }
+            case DISTINCT_COUNT: {
+                return processDISTINCT_COUNT(metric);
+            }
+            case LAST_VALUE: {
+                return processLAST_VALUE(metric);
+            }
+            case PERCENTILES: {
+                return processPERCENTILES(metric);
+            }
+            default: {
+                throw new IllegalStateException("Metric of type " + metric.getType() + " is not supported.");
+            }
+        }
     }
 
     @Override
     public void doJoins(SQLQueryBuilder sqlQueryBuilder, SQLQuery sqlQuery,
-                        FiltersProcessor filtersProcessor, GroupsProcessor groupsProcessor) {
+                        List<Filter> thriftFilters, IGroupExpressionProducer groupsProcessor) {
         if (lastValueTables != null) {
-            joinLastValueTables(sqlQueryBuilder, sqlQuery, filtersProcessor, groupsProcessor);
+            joinLastValueTables(sqlQueryBuilder, sqlQuery, thriftFilters, groupsProcessor);
         }
     }
 
@@ -143,6 +168,16 @@ public class DefaultMetricsProcessor implements MetricsProcessor {
     }
 
     // ==================== METRICS IMPLEMENTATION ====================
+
+
+    protected String createPercentileRowNumberAliasName(MetricPercentile percentile) {
+        return createPercentileRowNumberAliasName(percentile.getField());
+    }
+
+    @Override
+    public String createPercentileRowNumberAliasName(String percentileField) {
+        return aliasGenerator.generateForPercentiles(getPercentileFieldAliasPrefix() + percentileField + "_rn");
+    }
 
     protected ComparableExpressionBase processCOUNT(Metric m) {
         ComparableExpressionBase e;
@@ -190,6 +225,21 @@ public class DefaultMetricsProcessor implements MetricsProcessor {
         return e;
     }
 
+    protected ComparableExpressionBase processPERCENTILES(Metric m) {
+        final MetricPercentile mPercentile = m.getPercentile();
+        final NumberOperation<Double> percentilePath =
+                Expressions.numberOperation(Double.class, Ops.MULT,
+                        Expressions.numberOperation(Double.class, Ops.DIV,
+                                Expressions.numberPath(Long.class, table, createPercentileRowNumberAliasName(mPercentile)).doubleValue(),
+                                Expressions.numberPath(Long.class, table, getTotalCountAlias()).doubleValue()),
+                        constant(100));
+        return cases()
+                .when(Expressions.booleanOperation(Ops.GOE, percentilePath, constant(mPercentile.getMargin())))
+                .then(numberPath(Double.class, table, mPercentile.getField()))
+                .otherwise(Expressions.nullExpression())
+                .min();
+    }
+
     protected ComparableExpressionBase processLAST_VALUE(Metric m) {
         MetricLastValue metricLastValue = m.getLastValue();
         String field = metricLastValue.getField();
@@ -207,83 +257,109 @@ public class DefaultMetricsProcessor implements MetricsProcessor {
         }
 
         return cases()
-            .when(dateTimePath(Date.class, table, timeField)
-                .eq(dateTimePath(Date.class, lastValueTable.getPath(),
-                    getLastValueMaxTimeFieldAliasPrefix() + timeField)))
-            .then(stringPath(table, field))
-            .otherwise(nullExpression())
-            .max().as(getLastValueFieldAliasPrefix() + field + "_over_" +
-                Utils.underscore(timeField));
-    }
-
-    protected ComparableExpressionBase processPERCENTILES(Metric m) {
-        final MetricPercentile mPercentile = m.getPercentile();
-        final NumberOperation<Double> percentilePath =
-            Expressions.numberOperation(Double.class, Ops.MULT,
-                Expressions.numberOperation(Double.class, Ops.DIV,
-                    Expressions.numberPath(Long.class, table, createPercentileRowNumberAliasName(mPercentile)).doubleValue(),
-                    Expressions.numberPath(Long.class, table, getTotalCountAlias()).doubleValue()),
-                constant(100));
-        return cases()
-            .when(Expressions.booleanOperation(Ops.GOE, percentilePath, constant(mPercentile.getMargin())))
-            .then(numberPath(Double.class, table, mPercentile.getField()))
-            .otherwise(Expressions.nullExpression())
-            .min();
+                .when(dateTimePath(Date.class, table, timeField)
+                        .eq(dateTimePath(Date.class, lastValueTable.getPath(),
+                                getLastValueMaxTimeFieldAliasPrefix() + timeField)))
+                .then(stringPath(table, field))
+                .otherwise(nullExpression())
+                .max();
     }
 
     @SuppressWarnings("unchecked")
     protected void joinLastValueTables(SQLQueryBuilder sqlQueryBuilder, SQLQuery sqlQuery,
-                                       FiltersProcessor filtersProcessor, GroupsProcessor groupsProcessor) {
-        List<AliasedComparableExpressionBase> groupBy = groupsProcessor.getGroupBy();
+                                       List<Filter> thriftFilters, IGroupExpressionProducer groupsProcessor) {
+        List<AliasedComparableExpressionBase> groupBy = groupsProcessor.getExpressionsForGroupBy();
         List<Group> groups = groupsProcessor.getThriftGroups();
-        List<Filter> filters = filtersProcessor.getThriftFilters();
 
         for (Map.Entry<String, AliasedSimpleExpression<?>> entry : lastValueTables.entrySet()) {
             String timeField = entry.getKey();
             AliasedSimpleExpression<?> subqueryTableDef = entry.getValue();
             Path<?> subqueryTableRef = subqueryTableDef.getPath();
 
-            DateTimeExpression<Date> maxTimeFieldExpression = dateTimePath(Date.class, subqueryTableRef, timeField).max()
-                .as(getLastValueMaxTimeFieldAliasPrefix() + timeField);
+            DateTimeExpression<Date> maxTimeFieldExpression = dateTimePath(Date.class, subqueryTableRef, timeField)
+                    .max()
+                    .as(getLastValueMaxTimeFieldAliasPrefix() + timeField);
 
-            Predicate subqueryWhere = (filters == null) ? null :
-                sqlQueryBuilder.createFiltersProcessor().process(subqueryTableRef, filters);
+            Predicate subqueryWhere = (thriftFilters == null) ? null :
+                    sqlQueryBuilder.createFiltersProcessor(subqueryTableRef).process(thriftFilters);
 
             if (groupBy != null) {
                 // Same fields in GROUP BY, but by internal table.
-                List<AliasedComparableExpressionBase> subqueryGroupBy =
-                    sqlQueryBuilder.createGroupsProcessor().process(subqueryTableRef, groups, fieldMetadata);
+
+                IGroupExpressionProducer subqueryGroupsProcessor = sqlQueryBuilder.createGroupsProcessor()
+                        .process(subqueryTableRef, groups, fieldMetadata);
 
                 // SELECT contains all group fields and and MAX(<timeField>).
-                Expression[] subquerySelect = Utils.combine(subqueryGroupBy, maxTimeFieldExpression);
-
+                Expression[] subquerySelect = Utils.combine(
+                        subqueryGroupsProcessor.getExpressionsForSelect(),
+                        maxTimeFieldExpression
+                );
 
                 // Join by all GROUP BY fields.
-                BooleanBuilder subqueryOn = Utils.createFieldsEqualCoalescePredicate(groupBy, subqueryGroupBy, subqueryTableRef);
+                BooleanBuilder joinPredicate = buildLastValueHelpTableJoinPredicate(
+                        groupBy, subqueryGroupsProcessor.getExpressionsForSelect(), subqueryTableRef
+                );
 
                 sqlQuery.leftJoin(
-                    SQLExpressions
-                        .select(subquerySelect)
-                        .from(subqueryTableDef)
-                        .where(subqueryWhere)
-                        .groupBy(Utils.toArray(Expression.class, getSubqueryGroupBy(subqueryGroupBy))),
-                    subqueryTableRef)
-                    .on(subqueryOn);
+                        SQLExpressions
+                                .select(subquerySelect)
+                                .from(subqueryTableDef)
+                                .where(subqueryWhere)
+                                .groupBy(Utils.toArray(Expression.class, subqueryGroupsProcessor.getExpressionsForGroupBy())),
+                        subqueryTableRef
+                ).on(joinPredicate);
             } else {
                 // Just join MAX(<timeField>) to every row of the main table to make CASE() in SELECT in the same
                 // manner as when we have groups.
                 sqlQuery.from(
-                    SQLExpressions
-                        .select(maxTimeFieldExpression)
-                        .from(subqueryTableDef)
-                        .where(subqueryWhere),
-                    subqueryTableRef);
+                        SQLExpressions
+                                .select(maxTimeFieldExpression)
+                                .from(subqueryTableDef)
+                                .where(subqueryWhere),
+                        subqueryTableRef);
             }
         }
     }
 
-    protected List<AliasedComparableExpressionBase> getSubqueryGroupBy(List<AliasedComparableExpressionBase> subqueryGroupBy) {
-        return subqueryGroupBy;
+    protected BooleanBuilder buildLastValueHelpTableJoinPredicate(List<AliasedComparableExpressionBase> mainTableGroupBy,
+                                                                  List<AliasedComparableExpressionBase> helpTableGroupBy,
+                                                                  Path<?> helpTableRef) {
+        if (mainTableGroupBy.size() != helpTableGroupBy.size()) {
+            throw new IllegalArgumentException(format("Failed to build join predicate for Last Value help table due " +
+                    "to different number of expressions: %s vs %s", mainTableGroupBy, helpTableGroupBy));
+        }
+
+        List<StringExpression> leftExpressions = mainTableGroupBy.stream()
+                .map(AliasedComparableExpressionBase::original)
+                .map(this::toCoalesceExpression)
+                .collect(toList());
+        List<StringExpression> rightExpressions = helpTableGroupBy.stream()
+                .map(expression -> expression.hasAlias() ?
+                        comparablePath(expression.getType(), helpTableRef, expression.getAliasName()) : expression.original())
+                .map(this::toCoalesceExpression)
+                .collect(toList());
+
+        BooleanBuilder predicate = new BooleanBuilder();
+        Iterator<StringExpression> leftCoalesces = leftExpressions.iterator();
+        Iterator<StringExpression> rightCoalesces = rightExpressions.iterator();
+        while (leftCoalesces.hasNext()) {
+            predicate.and(leftCoalesces.next().eq(rightCoalesces.next()));
+        }
+        return predicate;
+    }
+
+    protected StringExpression toCoalesceExpression(ComparableExpressionBase<?> expression) {
+        return expression.coalesce(coalescePlaceholderFor(expression)).asString();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected Expression<?> coalescePlaceholderFor(ComparableExpressionBase<?> expression) {
+        if (Number.class.isAssignableFrom(expression.getType())) {
+            return Expressions.constant(987654321);
+        } else if (Date.class.isAssignableFrom(expression.getType())) {
+            return Expressions.constant(new Date(9876543210123L));
+        }
+        return Expressions.constant("COALESCE_987654321_PLACEHOLDER");
     }
 
     protected String getLastValueMaxTimeFieldAliasPrefix() {

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultRawSortsProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultRawSortsProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.impl;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultSQLQueryBuilder.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultSQLQueryBuilder.java
@@ -1,40 +1,60 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.impl;
 
 import com.google.common.collect.ImmutableList;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.SimpleExpression;
 import com.querydsl.core.types.dsl.SimplePath;
 import com.querydsl.core.types.dsl.SimpleTemplate;
-import com.querydsl.sql.*;
-import com.zoomdata.connector.example.framework.common.sql.*;
+import com.querydsl.sql.Configuration;
+import com.querydsl.sql.ProjectableSQLQuery;
+import com.querydsl.sql.SQLBindings;
+import com.querydsl.sql.SQLExpressions;
+import com.querydsl.sql.SQLQuery;
+import com.querydsl.sql.SQLTemplates;
+import com.zoomdata.connector.example.common.utils.StructuredUtils;
+import com.zoomdata.connector.example.common.utils.metadatabuilders.Filters;
+import com.zoomdata.connector.example.framework.common.sql.AggSortsProcessor;
+import com.zoomdata.connector.example.framework.common.sql.FieldsProcessor;
+import com.zoomdata.connector.example.framework.common.sql.FiltersProcessor;
+import com.zoomdata.connector.example.framework.common.sql.IGroupExpressionProducer;
+import com.zoomdata.connector.example.framework.common.sql.MetricsProcessor;
+import com.zoomdata.connector.example.framework.common.sql.ParametrizedQuery;
+import com.zoomdata.connector.example.framework.common.sql.RawSortsProcessor;
+import com.zoomdata.connector.example.framework.common.sql.SQLQueryBuilder;
+import com.zoomdata.connector.example.framework.common.sql.StatsProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.DefaultFilterTypeService;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
 import com.zoomdata.connector.example.framework.common.sql.types.DateTimeWithMillisPrecision;
 import com.zoomdata.gen.edc.filter.Filter;
-import com.zoomdata.gen.edc.filter.FilterFunction;
-import com.zoomdata.gen.edc.filter.FilterISNULL;
-import com.zoomdata.gen.edc.filter.FilterNOT;
 import com.zoomdata.gen.edc.group.Group;
 import com.zoomdata.gen.edc.metric.Metric;
 import com.zoomdata.gen.edc.request.StatField;
 import com.zoomdata.gen.edc.sort.AggSort;
 import com.zoomdata.gen.edc.sort.RawSort;
 import com.zoomdata.gen.edc.types.FieldMetadata;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static com.querydsl.core.types.dsl.Expressions.simplePath;
 import static com.querydsl.core.types.dsl.Expressions.stringPath;
-import static com.zoomdata.connector.example.framework.common.sql.impl.Utils.createPercentileRowNumberAliasName;
-import static java.util.Collections.emptyList;
+import static com.zoomdata.connector.example.common.utils.CollectionUtils.streamOfNullable;
+import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -75,16 +95,218 @@ public class DefaultSQLQueryBuilder implements SQLQueryBuilder {
         return this;
     }
 
-    @SuppressWarnings("unchecked")
-    protected AliasedSimpleExpression<String> createFromClause(String schemaName, String tableName, Boolean isCustomSql) {
-        if (isCustomSql) {
-            String customSql = tableName;
-            SimpleTemplate<String> fromExpression = Expressions.template(String.class, "("+customSql+")");
-            return AliasedSimpleExpression.create(fromExpression, TABLE_ALIAS);
+    private AliasedSimpleExpression<String> createFromClause(String schemaName, String tableName, Boolean isCustomSql) {
+        return isCustomSql ? createFromClauseForCustomSql(tableName) : createFromClauseForTable(schemaName, tableName);
+    }
+
+    protected AliasedSimpleExpression<String> createFromClauseForCustomSql(String customSql) {
+        SimpleTemplate<String> fromExpression = Expressions.template(String.class, "(" + customSql + ")");
+        return AliasedSimpleExpression.create(fromExpression, TABLE_ALIAS);
+    }
+
+    protected AliasedSimpleExpression<String> createFromClauseForTable(String schemaName, String tableName) {
+        SimplePath table;
+        if (StringUtils.isEmpty(schemaName)) {
+            table = simplePath(Object.class, tableName);
         } else {
             SimplePath schema = simplePath(Object.class, schemaName);
-            SimplePath table = simplePath(Object.class, schema, tableName);
-            return AliasedSimpleExpression.create(table, TABLE_ALIAS);
+            table = simplePath(Object.class, schema, tableName);
+        }
+        return AliasedSimpleExpression.create(table, TABLE_ALIAS);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public ParametrizedQuery build(SQLTemplates templates) {
+        validate();
+
+        FieldsProcessor fieldsProcessor = createFieldsProcessor();
+        MetricsProcessor metricProcessor = createMetricProcessor();
+        StatsProcessor statsProcessor = createStatsProcessor();
+        FiltersProcessor filtersProcessor = createFiltersProcessor(fromClause.getPath());
+        IGroupExpressionProducer groupsProcessor = createGroupsProcessor();
+        RawSortsProcessor rawSortsProcessor = createRawSortsProcessor();
+        AggSortsProcessor aggSortsProcessor = createAggSortsProcessor();
+
+        // TODO create separate factory class for this purpose
+        if (thriftFields != null) {
+            fieldsProcessor.process(fromClause.getPath(), thriftFields);
+        }
+        if (thriftMetrics != null) {
+            metricProcessor.process(fromClause.getPath(), thriftMetrics);
+        }
+        if (thriftGroups != null) {
+            groupsProcessor.process(fromClause.getPath(), thriftGroups, fieldMetadata);
+        }
+        if (thriftStats != null) {
+            statsProcessor.process(fromClause.getPath(), thriftStats);
+        }
+
+
+        Configuration config = new Configuration(templates);
+        config.register(new DateTimeWithMillisPrecision());
+        config.setUseLiterals(true);
+        SQLQuery sqlQuery = new SQLQuery(config);
+
+        Expression[] select = Utils.combineLists(
+                groupsProcessor.getExpressionsForSelect(),
+                fieldsProcessor.getSelect(),
+                metricProcessor.getSelect(),
+                statsProcessor.getSelect()
+        );
+
+        sqlQuery.select(select);
+        if (useSubSelectForPercentiles()) {
+            sqlQuery.from(
+                    createPercentileSubSelect(templates, metricProcessor, groupsProcessor),
+                    stringPath(TABLE_ALIAS)
+            );
+        } else {
+            sqlQuery.from(fromClause);
+            if (thriftFilters != null) {
+                filtersProcessor.process(thriftFilters);
+            }
+        }
+        sqlQuery.where(filtersProcessor.getWhere());
+
+        metricProcessor.doJoins(this, sqlQuery, thriftFilters, groupsProcessor);
+
+        if (thriftGroups != null) {
+            sqlQuery.groupBy(Utils.toArray(Expression.class, groupsProcessor.getExpressionsForGroupBy()));
+        }
+
+        if (thriftRawSorts != null || thriftAggSorts != null) {
+            List<OrderSpecifier> orderBy = null;
+
+            if (thriftRawSorts != null) {
+                orderBy = rawSortsProcessor.process(fromClause.getPath(), thriftRawSorts);
+            }
+
+            if (thriftAggSorts != null) {
+                orderBy = aggSortsProcessor.process(fromClause.getPath(), thriftAggSorts, metricProcessor, groupsProcessor);
+            }
+
+            sqlQuery.orderBy(Utils.toArray(OrderSpecifier.class, orderBy));
+        }
+
+        if (offset != null) {
+            sqlQuery.offset(offset);
+        }
+
+        if (limit != null) {
+            sqlQuery.limit(getSqlLimit(limit));
+        }
+
+        if (distinct) {
+            sqlQuery.distinct();
+        }
+
+        SQLBindings sqlBindings = sqlQuery.getSQL();
+
+        String sql = sqlBindings.getSQL();
+        ImmutableList<Object> params = sqlBindings.getBindings();
+
+        log.debug("sql " + sql);
+        return new ParametrizedQuery(sql, params);
+    }
+
+    protected long getSqlLimit(Integer limit) {
+        return limit.longValue();
+    }
+
+    protected boolean useSubSelectForPercentiles() {
+        return ofNullable(thriftMetrics)
+                .map(list -> !list.isEmpty() && list.stream().anyMatch(Metric::isSetPercentile))
+                .orElse(false);
+    }
+
+    private ProjectableSQLQuery createPercentileSubSelect(SQLTemplates templates,
+                                                          MetricsProcessor metricsProcessor,
+                                                          IGroupExpressionProducer groupsProcessor) {
+        Configuration config = new Configuration(templates);
+        config.setUseLiterals(true);
+
+        Expression<?>[] projection =
+                createPercentileSubSelectProjection(metricsProcessor, groupsProcessor).toArray(Expression<?>[]::new);
+
+        Predicate predicate = createPercentileSubSelectPredicate();
+
+        return new SQLQuery<Tuple>(config)
+                .select(projection).from(fromClause)
+                .where(predicate);
+    }
+
+    private Stream<Expression<?>> createPercentileSubSelectProjection(
+            MetricsProcessor metricsProcessor, IGroupExpressionProducer groupsProcessor) {
+
+        Expression<?>[] groupByExpressions =
+                streamOfNullable(groupsProcessor.getExpressionsForGroupBy())
+                        .map(AliasedComparableExpressionBase::withoutAlias)
+                        .toArray(Expression<?>[]::new);
+
+        Stream<Expression<?>> rowNumberExpressions = getPercentileFieldNames()
+                .map(fieldName -> SQLExpressions.rowNumber().over()
+                        .partitionBy(groupByExpressions)
+                        .orderBy(stringPath(fieldName))
+                        .as(metricsProcessor.createPercentileRowNumberAliasName(fieldName))
+                );
+        Expression<?> countExpression = SQLExpressions.count().over()
+                .partitionBy(groupByExpressions)
+                .as(DefaultMetricsProcessor.ALIAS_NAME_TTLCNT);
+
+        Stream<Expression<?>> fieldPaths = Stream.concat(
+                getMetricFieldNames(),
+                getGroupFieldNames()
+        ).distinct().map(Expressions::stringPath);
+
+        Stream<Expression<?>> windowFunctions = Stream.concat(
+                rowNumberExpressions,
+                Stream.of(countExpression)
+        );
+
+        return Stream.concat(fieldPaths, windowFunctions);
+    }
+
+    private Predicate createPercentileSubSelectPredicate() {
+        List<Filter> filters = Stream.concat(
+                streamOfNullable(thriftFilters),
+                getPercentileFieldNames().map(this::createNotNullFilter)
+        ).collect(toList());
+        return createFiltersProcessor(fromClause.getPath()).process(filters);
+    }
+
+    private Stream<String> getPercentileFieldNames() {
+        return streamOfNullable(thriftMetrics)
+                .filter(Metric::isSetPercentile)
+                .map(metric -> metric.getPercentile().getField())
+                .distinct();
+    }
+
+    private Stream<String> getMetricFieldNames() {
+        return streamOfNullable(thriftMetrics)
+                .map(StructuredUtils::getMetricName)
+                .filter(Objects::nonNull)
+                .distinct();
+    }
+
+    private Stream<String> getGroupFieldNames() {
+        return streamOfNullable(thriftGroups)
+                .map(StructuredUtils::getGroupName);
+    }
+
+    private Filter createNotNullFilter(String fieldName) {
+        return Filters.not(Filters.isNull(fieldName, fieldMetadata.get(fieldName).getType()));
+    }
+
+    protected void validate() {
+        if (thriftFields == null && thriftMetrics == null && thriftStats == null && thriftGroups == null) {
+            throw new IllegalStateException("At least one of fields, metrics, stats or groups must be defined.");
+        }
+        if (thriftRawSorts != null && thriftAggSorts != null) {
+            throw new IllegalStateException("RawSort and AggSort can't be defined simultaneously.");
+        }
+        if (fromClause.getPath() == null) {
+            throw new IllegalArgumentException("Alias to a from clause definition is required");
         }
     }
 
@@ -198,169 +420,7 @@ public class DefaultSQLQueryBuilder implements SQLQueryBuilder {
         return this;
     }
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public ParametrizedQuery build(SQLTemplates templates) {
-        validate();
-
-        FieldsProcessor fieldsProcessor = createFieldsProcessor();
-        MetricsProcessor metricProcessor = createMetricProcessor();
-        StatsProcessor statsProcessor = createStatsProcessor();
-        FiltersProcessor filtersProcessor = createFiltersProcessor();
-        GroupsProcessor groupsProcessor = createGroupsProcessor();
-        RawSortsProcessor rawSortsProcessor = createRawSortsProcessor();
-        AggSortsProcessor aggSortsProcessor = createAggSortsProcessor();
-
-        if (thriftFields != null) {
-            fieldsProcessor.process(fromClause.getPath(), thriftFields);
-        }
-        if (thriftMetrics != null) {
-            metricProcessor.process(fromClause.getPath(), thriftMetrics);
-        }
-        if (thriftGroups != null) {
-            groupsProcessor.process(fromClause.getPath(), thriftGroups, fieldMetadata);
-        }
-        if (thriftStats != null) {
-            statsProcessor.process(fromClause.getPath(), thriftStats);
-        }
-
-
-        Configuration config = new Configuration(templates);
-        config.register(new DateTimeWithMillisPrecision());
-        config.setUseLiterals(true);
-        SQLQuery sqlQuery = new SQLQuery(config);
-
-        Expression[] select = Utils.combineLists(
-                groupsProcessor.getGroupBy(),
-                fieldsProcessor.getSelect(),
-                metricProcessor.getSelect(),
-                statsProcessor.getSelect()
-        );
-
-        sqlQuery.select(select);
-        if (useSubSelectForPercentiles()) {
-            sqlQuery.from(
-                createSubSelectForPercentile(templates, groupsProcessor.getGroupBy()),
-                stringPath(TABLE_ALIAS)
-            );
-        } else {
-            sqlQuery.from(fromClause);
-        }
-        if (thriftFilters != null) {
-            filtersProcessor.process(fromClause.getPath(), thriftFilters);
-        }
-        sqlQuery.where(filtersProcessor.getWhere());
-
-        metricProcessor.doJoins(this, sqlQuery, filtersProcessor, groupsProcessor);
-
-        if (thriftGroups != null) {
-            sqlQuery.groupBy(Utils.toArray(Expression.class, groupsProcessor.getGroupBy()));
-        }
-
-        if (thriftRawSorts != null || thriftAggSorts != null) {
-            List<OrderSpecifier> orderBy = null;
-
-            if (thriftRawSorts != null) {
-                orderBy = rawSortsProcessor.process(fromClause.getPath(), thriftRawSorts);
-            }
-
-            if (thriftAggSorts != null) {
-                orderBy = aggSortsProcessor.process(fromClause.getPath(), thriftAggSorts, metricProcessor, groupsProcessor);
-            }
-
-            sqlQuery.orderBy(Utils.toArray(OrderSpecifier.class, orderBy));
-        }
-
-        if (offset != null) {
-            sqlQuery.offset(offset);
-        }
-
-        if (limit != null) {
-            sqlQuery.limit(limit);
-        }
-
-        if (distinct) {
-            sqlQuery.distinct();
-        }
-
-        SQLBindings sqlBindings = sqlQuery.getSQL();
-
-        String sql = sqlBindings.getSQL();
-        ImmutableList<Object> params = sqlBindings.getBindings();
-
-        log.debug("sql " + sql);
-        return new ParametrizedQuery(sql, params);
-    }
-
-    protected boolean useSubSelectForPercentiles() {
-        return Optional.ofNullable(thriftMetrics)
-            .map(list -> !list.isEmpty() && list.stream().anyMatch(Metric::isSetPercentile))
-            .orElse(false);
-    }
-
-    protected ProjectableSQLQuery createSubSelectForPercentile(SQLTemplates templates,
-                                                            List<AliasedComparableExpressionBase> groupBy) {
-        final List<AliasedComparableExpressionBase> groupByWithOutAlias =
-            Optional.ofNullable(groupBy)
-            .map(l -> l.stream().map(AliasedComparableExpressionBase::withoutAlias).collect(toList()))
-            .orElse(emptyList());
-        final List<SimpleExpression<Long>> percentileWindowFunctions = thriftMetrics.stream()
-            .filter(Metric::isSetPercentile)
-            .map(Metric::getPercentile)
-            .distinct()
-            .map(percentile -> SQLExpressions.rowNumber()
-                .over()
-                .partitionBy(Utils.toArray(Expression.class, groupByWithOutAlias))
-                .orderBy(stringPath(percentile.getField()))
-                .as(createPercentileRowNumberAliasName(String.valueOf(percentile.getMargin()))))
-            .collect(toList());
-        percentileWindowFunctions.add(SQLExpressions.count().over()
-            .partitionBy(Utils.toArray(Expression.class, groupByWithOutAlias))
-            .as(DefaultMetricsProcessor.ALIAS_NAME_TTLCNT));
-        Configuration config = new Configuration(templates);
-        config.setUseLiterals(true);
-        SQLQuery sqlQuery = new SQLQuery(config);
-
-        final ProjectableSQLQuery query = sqlQuery.select(
-            Utils.combineLists(
-                fieldMetadata.keySet().stream().map(name -> stringPath(name)).collect(toList()),
-                percentileWindowFunctions))
-            .from(fromClause);
-
-        if (thriftFilters != null) {
-            thriftFilters.addAll(createNotNullPercentileFilter());
-            query.where(createFiltersProcessor().process(fromClause.getPath(), thriftFilters));
-            thriftFilters = null;
-        } else {
-            query.where(createFiltersProcessor().process(fromClause.getPath(), createNotNullPercentileFilter()));
-        }
-
-
-        return query;
-    }
-
-    private List<Filter> createNotNullPercentileFilter() {
-        return thriftMetrics.stream()
-            .filter(Metric::isSetPercentile)
-            .map(m -> m.getPercentile().getField())
-            .distinct().map(perc -> new Filter(FilterFunction.NOT)
-            .setFilterNOT(new FilterNOT(new Filter(FilterFunction.IS_NULL)
-                .setFilterISNULL(new FilterISNULL(perc, fieldMetadata.get(perc).getType())
-                )))).collect(toList());
-    }
-
-    protected void validate() {
-        if (thriftFields == null && thriftMetrics == null && thriftStats == null && thriftGroups == null) {
-            throw new IllegalStateException("At least one of fields, metrics, stats or groups must be defined.");
-        }
-        if (thriftRawSorts != null && thriftAggSorts != null) {
-            throw new IllegalStateException("RawSort and AggSort can't be defined simultaneously.");
-        }
-        if (fromClause.getPath() == null) {
-            throw new IllegalArgumentException("Alias to a from clause definition is required");
-        }
-    }
-
+    // TODO create separate factory class for this purpose
     @Override
     public FieldsProcessor createFieldsProcessor() {
         return new DefaultFieldsProcessor();
@@ -377,13 +437,14 @@ public class DefaultSQLQueryBuilder implements SQLQueryBuilder {
     }
 
     @Override
-    public FiltersProcessor createFiltersProcessor() {
-        return new DefaultFiltersProcessor();
+    public FiltersProcessor createFiltersProcessor(Path<?> table) {
+        return new DefaultFiltersProcessor(table, Optional.ofNullable(fieldMetadata).orElse(Collections.emptyMap()),
+                createFilterTypeService());
     }
 
     @Override
-    public GroupsProcessor createGroupsProcessor() {
-        return new DefaultGroupsProcessor(serverTimeZone);
+    public IGroupExpressionProducer createGroupsProcessor() {
+        return new GroupExpressionProducer();
     }
 
     @Override
@@ -395,4 +456,9 @@ public class DefaultSQLQueryBuilder implements SQLQueryBuilder {
     public AggSortsProcessor createAggSortsProcessor() {
         return new DefaultAggSortsProcessor();
     }
+
+    protected FilterTypeService createFilterTypeService() {
+        return new DefaultFilterTypeService();
+    }
+
 }

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultStatsProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/DefaultStatsProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.impl;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/GroupExpressionProducer.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/GroupExpressionProducer.java
@@ -1,0 +1,314 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.impl;
+
+import com.google.common.base.Supplier;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.NumberTemplate;
+import com.querydsl.core.types.dsl.StringExpression;
+import com.querydsl.core.types.dsl.TemporalExpression;
+import com.zoomdata.connector.example.common.utils.struct.Pair;
+import com.zoomdata.connector.example.framework.common.sql.IAliasGenerator;
+import com.zoomdata.connector.example.framework.common.sql.IGroupExpressionProducer;
+import com.zoomdata.gen.edc.group.Group;
+import com.zoomdata.gen.edc.group.GroupType;
+import com.zoomdata.gen.edc.group.HistogramGroup;
+import com.zoomdata.gen.edc.group.TimeGroup;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import org.springframework.util.Assert;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.querydsl.core.types.dsl.Expressions.cases;
+import static com.querydsl.core.types.dsl.Expressions.dateTimePath;
+import static com.querydsl.core.types.dsl.Expressions.numberPath;
+import static com.querydsl.core.types.dsl.Expressions.numberTemplate;
+import static com.querydsl.core.types.dsl.Expressions.stringPath;
+import static com.zoomdata.connector.example.common.utils.CollectionUtils.toSpecificMap;
+import static java.lang.String.format;
+import static java.util.Optional.ofNullable;
+
+public final class GroupExpressionProducer implements IGroupExpressionProducer {
+
+    public static final String HISTOGRAM_MSG_START_GREATER_END =
+            "Start point of histogram group is greater then end point.";
+    public static final String HISTOGRAM_MSG_NEGATIVE_BUCKET_SIZE = "Bucket size is less or equal to zero.";
+    public static final String HISTOGRAM_MSG_LESS_THAN_ONE_BUCKET = "Histogram should have more then one bucket!";
+
+    public static final String HISTOGRAM_GROUP_FIELD_ALIAS_PREFIX = "__hg_";
+    public static final String TIME_GROUP_FIELD_ALIAS_PREFIX = "__tg_";
+    public static final String HISTOGRAM_GROUP_FIELD_ALIAS_PREFIX_WHICH_STARTS_WITH_LETTER = "hg_";
+    public static final String TIME_GROUP_FIELD_ALIAS_PREFIX_WHICH_STARTS_WITH_LETTER = "tg_";
+
+    private Path<?> table;
+    private List<Group> thriftGroups;
+    private Map<Group, AliasedComparableExpressionBase> groupExpressions;
+
+    private String histogramGroupFieldAliasPrefix = HISTOGRAM_GROUP_FIELD_ALIAS_PREFIX;
+    private String timeGroupFieldAliasPrefix = TIME_GROUP_FIELD_ALIAS_PREFIX;
+
+    private boolean useAliasInsteadOfOriginalExpressionInGroupByClause = true;
+    private boolean useAliasInsteadOfOriginalExpressionInOrderByClause = true;
+
+    private IAliasGenerator aliasGenerator;
+    private Supplier<AliasGenerator> aliasGeneratorSupplier = () -> AliasGenerator.newAliasGenerator().build();
+    private TimeGroupExpressionProducer timeGroupExpressionProducer = new TimeGroupExpressionProducer();
+
+    public GroupExpressionProducer() {
+    }
+
+    public GroupExpressionProducer useOriginalExpressionInGroupByClause() {
+        this.useAliasInsteadOfOriginalExpressionInGroupByClause = false;
+        return this;
+    }
+
+    public GroupExpressionProducer useOriginalExpressionInOrderByClause() {
+        this.useAliasInsteadOfOriginalExpressionInOrderByClause = false;
+        return this;
+    }
+
+    public GroupExpressionProducer withHistogramGroupFieldAliasPrefix(String prefix) {
+        this.histogramGroupFieldAliasPrefix = prefix;
+        return this;
+    }
+
+    public GroupExpressionProducer withTimeGroupFieldAliasPrefix(String prefix) {
+        this.timeGroupFieldAliasPrefix = prefix;
+        return this;
+    }
+
+    public GroupExpressionProducer withHistogramAndTimeGroupFieldAliasPrefixStartingWithLetter() {
+        return this
+                .withHistogramGroupFieldAliasPrefix(HISTOGRAM_GROUP_FIELD_ALIAS_PREFIX_WHICH_STARTS_WITH_LETTER)
+                .withTimeGroupFieldAliasPrefix(TIME_GROUP_FIELD_ALIAS_PREFIX_WHICH_STARTS_WITH_LETTER);
+    }
+
+    public GroupExpressionProducer useAliasGeneratorSupplier(Supplier<AliasGenerator> supplier) {
+        this.aliasGeneratorSupplier = supplier;
+        return this;
+    }
+
+    public IGroupExpressionProducer withTimeGroupExpressionProducer(TimeGroupExpressionProducer timeGroupExpressionProducer) {
+        this.timeGroupExpressionProducer = timeGroupExpressionProducer;
+        return this;
+    }
+
+    // ==================== INTERFACE IMPLEMENTATION ====================
+
+    @Override
+    public GroupExpressionProducer
+    process(
+            Path<?> table,
+            List<Group> groups,
+            Map<String, FieldMetadata> fieldMetadata
+    ) {
+        aliasGenerator = aliasGeneratorSupplier.get();
+        this.table = table;
+        this.thriftGroups = groups;
+        this.groupExpressions = ofNullable(groups).map(gr -> gr.stream()
+                .map(g -> transformGroupToExpression(g, fieldMetadata))
+                .collect(
+                        toSpecificMap(Pair::getLeft, Pair::getRight, LinkedHashMap::new)
+                )
+        ).orElse(null);
+        return this;
+    }
+
+    @Override
+    public List<Group> getThriftGroups() {
+        return thriftGroups;
+    }
+
+    @Override
+    public List<AliasedComparableExpressionBase> getExpressionsForSelect() {
+        return getExpressionsAsList();
+    }
+
+    @Override
+    public List<AliasedComparableExpressionBase> getExpressionsForGroupBy() {
+        return useAliasInsteadOfOriginalExpressionInGroupByClause ? getExpressionsAsList() :
+                mapGroupExpressions(expressions -> transformExpressionMapToList(
+                        expressions,
+                        AliasedComparableExpressionBase::withoutAlias
+                        )
+                );
+    }
+
+    @Override
+    public AliasedComparableExpressionBase getExpressionForOrderBy(Group group) {
+        return mapGroupExpressions((Map<Group, AliasedComparableExpressionBase> expressions) -> getExpression(
+                expressions,
+                group,
+                useAliasInsteadOfOriginalExpressionInOrderByClause
+                )
+        );
+    }
+
+
+    // ==================== GROUPS IMPLEMENTATION ====================
+
+    private Pair<Group, AliasedComparableExpressionBase> transformGroupToExpression(
+            Group g, Map<String,
+            FieldMetadata> fieldMetadata
+    ) {
+
+        AliasedComparableExpressionBase e;
+        GroupType type = g.getType();
+        switch (type) {
+            case ATTRIBUTE_GROUP: {
+                e = processATTRIBUTE_GROUP(table, g, fieldMetadata);
+                break;
+            }
+            case HISTOGRAM_GROUP: {
+                e = processHISTOGRAM_GROUP(g);
+                break;
+            }
+            case TIME_GROUP: {
+                e = processTIME_GROUP(g, fieldMetadata);
+                break;
+            }
+            default: {
+                throw new IllegalStateException("Group of type " + type + " is not supported.");
+            }
+        }
+        return Pair.create(g, e);
+    }
+
+    private AliasedComparableExpressionBase processATTRIBUTE_GROUP(
+            Path<?> table,
+            Group g,
+            Map<String, FieldMetadata> fieldMetadata
+    ) {
+        String field = g.getAttributeGroup().getField();
+        FieldMetadata metadata = fieldMetadata.get(field);
+        ComparableExpressionBase<?> path;
+        switch (metadata.getType()) {
+            case DATE:
+                path = dateTimePath(Date.class, table, field);
+                break;
+            case INTEGER:
+                path = numberPath(Integer.class, table, field);
+                break;
+            case DOUBLE:
+                path = numberPath(Double.class, table, field);
+                break;
+            case STRING:
+                path = stringPath(table, field);
+                break;
+            // TODO [oleksandr.chornyi]: What to do with UNKNOWN type?
+            default:
+                throw new IllegalArgumentException("Type mapping not found for type: " + metadata.getType());
+        }
+        return AliasedComparableExpressionBase.create(path, aliasGenerator.generate(field));
+    }
+
+    private AliasedComparableExpressionBase processHISTOGRAM_GROUP(Group g) {
+        HistogramGroup group = g.getHistogramGroup();
+        double[] points = getHistogramGroupPoints(group);
+        NumberPath<Double> field = numberPath(Double.class, table, group.getField());
+
+        // Starting point: ( -inf; start ]
+        CaseBuilder.Cases<String, StringExpression> cases = cases()
+                .when(field.loe(doubleTemplate(points[0]))).then(";" + points[0]);
+        // Several points. Every sub-interval is (x, y]
+        for (int p = 1; p < points.length; p++) {
+            cases.when(field.gt(doubleTemplate(points[p - 1])).and(field.loe(doubleTemplate(points[p]))))
+                    .then(points[p - 1] + ";" + points[p]);
+        }
+        // Last point: (end; +inf)
+        StringExpression expression = cases.otherwise(points[points.length - 1] + ";");
+
+        return AliasedComparableExpressionBase.create(
+                expression,
+                aliasGenerator.generate(histogramGroupFieldAliasPrefix + Utils.underscore(group.getField()))
+        );
+    }
+
+    // TODO can we make this class private?
+    double[] getHistogramGroupPoints(HistogramGroup group) {
+        BigDecimal startPoint = BigDecimal.valueOf(group.getStartPoint()).stripTrailingZeros();
+        BigDecimal endPoint = BigDecimal.valueOf(group.getEndPoint()).stripTrailingZeros();
+        BigDecimal bucketSize = BigDecimal.valueOf(group.getBucketSize()).stripTrailingZeros();
+
+        if (startPoint.compareTo(endPoint) >= 0) {
+            throw new IllegalArgumentException(HISTOGRAM_MSG_START_GREATER_END + printHistogram(group));
+        }
+        if (bucketSize.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException(HISTOGRAM_MSG_NEGATIVE_BUCKET_SIZE + printHistogram(group));
+        }
+        if (endPoint.subtract(startPoint).compareTo(bucketSize) <= 0) {
+            throw new IllegalArgumentException(HISTOGRAM_MSG_LESS_THAN_ONE_BUCKET + printHistogram(group));
+        }
+
+        BigDecimal pointCountDecimal = endPoint.subtract(startPoint).divide(bucketSize, 0, BigDecimal.ROUND_DOWN);
+        int pointCount = pointCountDecimal.intValue();
+        //exclude point which equals to end point
+        if(pointCountDecimal.multiply(bucketSize).add(startPoint).compareTo(endPoint) == 0){
+            pointCount--;
+        }
+        return IntStream.range(0, pointCount)
+                .mapToDouble(i -> startPoint.add(bucketSize.multiply(new BigDecimal(i + 1))).doubleValue())
+                .toArray();
+    }
+
+    private String printHistogram(HistogramGroup histogram) {
+        return format(" Start: %f, end: %f, bucketSize: %f", histogram.getStartPoint(), histogram.getEndPoint(),
+                histogram.getBucketSize());
+    }
+
+    private AliasedComparableExpressionBase processTIME_GROUP(Group g, Map<String, FieldMetadata> metadata) {
+        TimeGroup timeGroup = g.getTimeGroup();
+        FieldMetadata fieldMetadata = metadata.get(timeGroup.getField());
+        Assert.isTrue(timeGroup.getField().equals(fieldMetadata.getName()),
+                "FieldMetadata name and TimeGroup name doesn't match: " + fieldMetadata.getName() + " vs " + timeGroup.getField());
+        TemporalExpression<?> groupExpression = timeGroupExpressionProducer.process(table, timeGroup, fieldMetadata);
+
+        return AliasedComparableExpressionBase.create(
+                groupExpression,
+                aliasGenerator.generate(
+                        timeGroupFieldAliasPrefix + timeGroup.getGranularity().name().toLowerCase() + "_over_" +
+                                Utils.underscore(timeGroup.getField())
+                )
+        );
+    }
+
+    public static NumberTemplate<Double> doubleTemplate(double val) {
+        return numberTemplate(Double.class, String.valueOf(val));
+    }
+
+    private <T> T mapGroupExpressions(Function<Map<Group, AliasedComparableExpressionBase>, T> f) {
+        return ofNullable(groupExpressions).map(f).orElse(null);
+    }
+
+    private List<AliasedComparableExpressionBase> transformExpressionMapToList(
+            Map<Group, AliasedComparableExpressionBase> expressions,
+            Function<AliasedComparableExpressionBase, AliasedComparableExpressionBase> f
+    ) {
+        return expressions.values().stream().map(f).collect(Collectors.toList());
+    }
+
+    private List<AliasedComparableExpressionBase> getExpressionsAsList() {
+        return mapGroupExpressions(expressions -> transformExpressionMapToList(expressions, Function.identity()));
+    }
+
+    private AliasedComparableExpressionBase getExpression(
+            Map<Group, AliasedComparableExpressionBase> expressions,
+            Group group,
+            boolean withAlias
+    ) {
+        AliasedComparableExpressionBase expression = expressions.get(group);
+        return withAlias ? expression : expression.withoutAlias();
+    }
+
+}

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/TimeGroupExpressionProducer.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/TimeGroupExpressionProducer.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.framework.common.sql.impl;
+
+import com.querydsl.core.types.Operator;
+import com.querydsl.core.types.Ops;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.NumberPath;
+import com.querydsl.core.types.dsl.TemporalExpression;
+import com.zoomdata.connector.example.framework.common.sql.ops.ExtendedDateTimeOps;
+import com.zoomdata.gen.edc.group.TimeGroup;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import com.zoomdata.gen.edc.types.FieldParams;
+import com.zoomdata.gen.edc.types.FieldType;
+import com.zoomdata.gen.edc.types.TimeGranularity;
+
+import java.util.Date;
+import java.util.Optional;
+
+import static com.querydsl.core.types.dsl.Expressions.dateTimeOperation;
+import static com.querydsl.core.types.dsl.Expressions.dateTimePath;
+import static com.querydsl.core.types.dsl.Expressions.numberPath;
+import static com.zoomdata.connector.example.framework.common.sql.impl.Utils.SECONDS_FORMAT;
+import static com.zoomdata.connector.example.framework.common.sql.impl.Utils.YEAR_FORMAT;
+import static java.util.Optional.ofNullable;
+
+/**
+ * TODO: introduce a separate format for milliseconds
+ */
+public class TimeGroupExpressionProducer {
+
+    public TemporalExpression<Date> process(Path<?> table, TimeGroup group, FieldMetadata fieldMetadata) {
+        Operator truncationOperator = defineTruncationOperator(group.getGranularity(), fieldMetadata);
+        TemporalExpression<Date> pathToTimeField = createPathToTimeField(table, fieldMetadata);
+        // TODO [oleksandr.chornyi]: Add verification that the target time group granularity makes sense for such a field
+        if (isDateInYearFormat(fieldMetadata)) {
+            return pathToTimeField;
+        }
+        return dateTimeOperation(Date.class, truncationOperator, pathToTimeField);
+    }
+
+    protected TemporalExpression<Date> createPathToTimeField(Path<?> table, FieldMetadata fieldMetadata) {
+        if (fieldMetadata.getType() == FieldType.DATE) {
+            return datePath(table, fieldMetadata);
+        } else if (isDateInYearFormat(fieldMetadata)) {
+            checkYearPatternGranularity(fieldMetadata);
+            return yearPath(table, fieldMetadata);
+        } else if (isDateInSecondsFormat(fieldMetadata)) {
+            return secondsPath(table, fieldMetadata);
+        } else {
+            checkTimeGroupFieldType(fieldMetadata);
+            return millisecondsPath(table, fieldMetadata);
+        }
+    }
+
+    protected TemporalExpression<Date> datePath(Path<?> table, FieldMetadata fieldMetadata) {
+        return dateTimePath(Date.class, table, fieldMetadata.getName());
+    }
+
+    protected TemporalExpression<Date> yearPath(Path<?> table, FieldMetadata fieldMetadata) {
+        NumberPath<Long> yearFieldPath = numberPath(Long.class, table, fieldMetadata.getName());
+        return dateTimeOperation(Date.class, ExtendedDateTimeOps.FROM_YEARPATTERN, yearFieldPath);
+    }
+
+    protected TemporalExpression<Date> secondsPath(Path<?> table, FieldMetadata fieldMetadata) {
+        NumberPath<Long> unixtimeFieldPath = numberPath(Long.class, table, fieldMetadata.getName());
+        return  dateTimeOperation(Date.class, ExtendedDateTimeOps.FROM_UNIXTIME, unixtimeFieldPath);
+    }
+
+    protected TemporalExpression<Date> millisecondsPath(Path<?> table, FieldMetadata fieldMetadata) {
+        NumberPath<Long> millisFieldPath = numberPath(Long.class, table, fieldMetadata.getName());
+        return dateTimeOperation(Date.class, ExtendedDateTimeOps.FROM_MILLIS, millisFieldPath);
+    }
+
+
+    private static boolean isDateInYearFormat(FieldMetadata fieldMetadata) {
+        Optional<String> timeFieldPattern = getTimeFieldPattern(fieldMetadata);
+        return timeFieldPattern.isPresent() && YEAR_FORMAT.equals(timeFieldPattern.get());
+    }
+
+    private static boolean isDateInSecondsFormat(FieldMetadata fieldMetadata) {
+        return getTimeFieldPattern(fieldMetadata).filter(SECONDS_FORMAT::equals).isPresent();
+    }
+
+    private static Optional<String> getTimeFieldPattern(FieldMetadata fieldMetadata) {
+        return ofNullable(fieldMetadata.getFieldParams()).map(FieldParams::getTimeFieldPattern);
+    }
+
+    protected Operator defineTruncationOperator(TimeGranularity granularity, FieldMetadata fieldMetadata) {
+        switch (granularity) {
+            case MILLISECOND: {
+                throw new UnsupportedOperationException(granularity + " time granularity is not supported");
+            }
+            case SECOND: {
+                return Ops.DateTimeOps.TRUNC_SECOND;
+            }
+            case MINUTE: {
+                return Ops.DateTimeOps.TRUNC_MINUTE;
+            }
+            case HOUR: {
+                return Ops.DateTimeOps.TRUNC_HOUR;
+            }
+            case DAY: {
+                return Ops.DateTimeOps.TRUNC_DAY;
+            }
+            case WEEK: {
+                return Ops.DateTimeOps.TRUNC_WEEK;
+            }
+            case MONTH: {
+                return Ops.DateTimeOps.TRUNC_MONTH;
+            }
+            case QUARTER: {
+                return ExtendedDateTimeOps.TRUNC_QUARTER;
+            }
+            case YEAR: {
+                return Ops.DateTimeOps.TRUNC_YEAR;
+            }
+            default: {
+                throw new IllegalStateException("Time group with granularity " + granularity + " is not supported.");
+            }
+        }
+    }
+
+    private static void checkYearPatternGranularity(FieldMetadata fieldMetadata) {
+        if (fieldMetadata.getFieldParams().getTimeFieldGranularity() != TimeGranularity.YEAR) {
+            throw new IllegalArgumentException("Year column can't have granularity " +
+                    fieldMetadata.getFieldParams().getTimeFieldGranularity());
+        }
+    }
+
+    private static void checkTimeGroupFieldType(FieldMetadata fieldMetadata) {
+        if (fieldMetadata.getType() == FieldType.STRING) {
+            throw new IllegalArgumentException("Unable to create a time group using a field of type String: " + fieldMetadata);
+        }
+    }
+
+}
+

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/Utils.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/impl/Utils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.impl;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/ops/ExtendedDateTimeOps.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/ops/ExtendedDateTimeOps.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.ops;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/common/sql/types/DateTimeWithMillisPrecision.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/common/sql/types/DateTimeWithMillisPrecision.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.common.sql.types;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/AbstractSqlComputeTask.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/AbstractSqlComputeTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 
 package com.zoomdata.connector.example.framework.provider;

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/ConnectorBeanNameGenerator.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/ConnectorBeanNameGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/GenericSQLDataProvider.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/GenericSQLDataProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/GenericTypesMapping.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/GenericTypesMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/ServerFeatures.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/ServerFeatures.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/SqlPreparedQueryComputeTask.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/SqlPreparedQueryComputeTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/SqlPreparedQueryComputeTaskFactory.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/SqlPreparedQueryComputeTaskFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/SqlQueryComputeTask.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/SqlQueryComputeTask.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/SqlQueryComputeTaskFactory.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/SqlQueryComputeTaskFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/GenericDescriptionProvider.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/GenericDescriptionProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider.serverdescription;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/IConnectionParameter.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/IConnectionParameter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider.serverdescription.connectionparameters;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/IConnectionParameterBuilder.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/IConnectionParameterBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider.serverdescription.connectionparameters;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/impl/AbstractConnectionParameter.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/impl/AbstractConnectionParameter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider.serverdescription.connectionparameters.impl;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/impl/BooleanConnectionParameter.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/impl/BooleanConnectionParameter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider.serverdescription.connectionparameters.impl;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/impl/EnumConnectionParameter.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/impl/EnumConnectionParameter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider.serverdescription.connectionparameters.impl;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/impl/IntegerConnectionParameter.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/impl/IntegerConnectionParameter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider.serverdescription.connectionparameters.impl;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/impl/PasswordConnectionParameter.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/impl/PasswordConnectionParameter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider.serverdescription.connectionparameters.impl;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/impl/StringConnectionParameter.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/provider/serverdescription/connectionparameters/impl/StringConnectionParameter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.provider.serverdescription.connectionparameters.impl;
 

--- a/src/main/java/com/zoomdata/connector/example/framework/service/ZoomdataConnectorService.java
+++ b/src/main/java/com/zoomdata/connector/example/framework/service/ZoomdataConnectorService.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.framework.service;
 

--- a/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBDataProvider.java
+++ b/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBDataProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.provider.cratedb;
 

--- a/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBFeatures.java
+++ b/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBFeatures.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.provider.cratedb;
 

--- a/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBSQLTemplates.java
+++ b/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBSQLTemplates.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.provider.cratedb;
 

--- a/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBTypesMapping.java
+++ b/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBTypesMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.provider.cratedb;
 

--- a/src/main/java/com/zoomdata/connector/example/provider/cratedb/sql/CrateDBFiltersProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/provider/cratedb/sql/CrateDBFiltersProcessor.java
@@ -1,81 +1,21 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.provider.cratedb.sql;
 
-import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Path;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
 import com.zoomdata.connector.example.framework.common.sql.impl.DefaultFiltersProcessor;
-import com.zoomdata.gen.edc.filter.*;
-import com.zoomdata.gen.edc.types.FieldType;
+import com.zoomdata.gen.edc.filter.FilterFunction;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+
+import java.util.Map;
 
 public class CrateDBFiltersProcessor extends DefaultFiltersProcessor {
 
-    /*  When negating most filters, CrateDB will include NULL values such that, we have 1,500 records
-     *  The column string_null has 15 values = 'Alaska', 453 nulls, and the rest other values. When we
-     *
-     *  select count(*) FROM myTable WHERE not string_field = 'Alaska'
-     *
-     *  CrateDB gives us 1,485, while Zoomdata expects 1,032, i.e., Zoomdata expects not to count the nulls. So
-     *  when we have a NOT filter we have to adjust the filter to look like
-     *
-     *  select count(*) FROM myTable WHERE not (string_field = 'Alaska' OR string_field is null)
-      * */
-    @Override
-    protected void processNOT(Path<?> table, Filter filter, BooleanBuilder predicate) {
-        Filter filterForNot = filter.getFilterNOT().getFilter();
-        // Only apply to operators it could affect
-        if(filterHasAffectedClause(filterForNot)) {
-            // Type doesn't matter for a NULL filter, so use anything the filter processor will accept
-            Filter filterIsNull = new Filter().setType(FilterFunction.IS_NULL)
-                .setFilterISNULL(new FilterISNULL().setPath(extractFilterPath(filterForNot)).setType(FieldType.STRING));
-
-            // Create an OR filter that takes the original condition and will also use IS NULL
-            FilterOR filterOr = new FilterOR();
-            filterOr.addToFilters(filterForNot);
-            filterOr.addToFilters(filterIsNull);
-
-            // Negate the filter such that NOT (field = someVal OR field is null)
-            Filter outermostFilter = new Filter().setType(FilterFunction.NOT).setFilterNOT(
-                new FilterNOT().setFilter(new Filter().setType(FilterFunction.OR).setFilterOR(filterOr)));
-
-            // Process the new adjusted filter as normal
-            super.processNOT(table, outermostFilter, predicate);
-        } else {
-            super.processNOT(table, filter, predicate);
-        }
-    }
-
-    private static boolean filterHasAffectedClause(Filter filter) {
-        return filter.isSetFilterEQ() || filter.isSetFilterEQI() || filter.isSetFilterGE() || filter.isSetFilterCONTAINS() ||
-            filter.isSetFilterENDS_WITH() || filter.isSetFilterGT() || filter.isSetFilterIN() || filter.isSetFilterLE() ||
-            filter.isSetFilterLT() || filter.isSetFilterSTARTS_WITH() || filter.isSetFilterTEXT_SEARCH();
-    }
-
-    private static String extractFilterPath(Filter filter) {
-        if(filter.isSetFilterEQ()) {
-            return filter.getFilterEQ().getPath();
-        } else if (filter.isSetFilterEQI()) {
-            return filter.getFilterEQI().getPath();
-        } else if (filter.isSetFilterCONTAINS()) {
-            return filter.getFilterCONTAINS().getPath();
-        } else if (filter.isSetFilterGE()) {
-            return filter.getFilterGE().getPath();
-        } else if (filter.isSetFilterGT()) {
-            return filter.getFilterGT().getPath();
-        } else if (filter.isSetFilterLE()) {
-            return filter.getFilterLE().getPath();
-        } else if (filter.isSetFilterLT()) {
-            return filter.getFilterLT().getPath();
-        } else if (filter.isSetFilterIN()) {
-            return filter.getFilterIN().getPath();
-        } else if (filter.isSetFilterSTARTS_WITH()) {
-            return filter.getFilterSTARTS_WITH().getPath();
-        } else if (filter.isSetFilterENDS_WITH()) {
-            return filter.getFilterENDS_WITH().getPath();
-        } else if (filter.isSetFilterTEXT_SEARCH()) {
-            return filter.getFilterTEXT_SEARCH().getPath();
-        }
-        throw new IllegalArgumentException("Invalid filter type for altering NOT clause");
+    public CrateDBFiltersProcessor(Path<?> table, Map<String, FieldMetadata> metadata,
+                                   FilterTypeService filterTypeService) {
+        super(table, metadata, filterTypeService);
+        addFilterProcessor(FilterFunction.NOT, new CrateDbNotFilterProcessor(this));
     }
 }

--- a/src/main/java/com/zoomdata/connector/example/provider/cratedb/sql/CrateDBSQLQueryBuilder.java
+++ b/src/main/java/com/zoomdata/connector/example/provider/cratedb/sql/CrateDBSQLQueryBuilder.java
@@ -1,15 +1,26 @@
 /**
- * Copyright (C) Zoomdata, Inc. 2012-2016. All rights reserved.
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
  */
 package com.zoomdata.connector.example.provider.cratedb.sql;
 
+import com.querydsl.core.types.Path;
 import com.zoomdata.connector.example.framework.common.sql.FiltersProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.DefaultFilterTypeService;
+import com.zoomdata.connector.example.framework.common.sql.filter.type.FilterTypeService;
 import com.zoomdata.connector.example.framework.common.sql.impl.DefaultSQLQueryBuilder;
+
+import java.util.Collections;
+import java.util.Optional;
 
 public class CrateDBSQLQueryBuilder extends DefaultSQLQueryBuilder {
 
     @Override
-    public FiltersProcessor createFiltersProcessor() {
-        return new CrateDBFiltersProcessor();
+    public FiltersProcessor createFiltersProcessor(Path<?> table) {
+        return new CrateDBFiltersProcessor(table, Optional.ofNullable(fieldMetadata).orElse(Collections.emptyMap()),
+                createFilterTypeService());
+    }
+
+    protected FilterTypeService createFilterTypeService() {
+        return new DefaultFilterTypeService();
     }
 }

--- a/src/main/java/com/zoomdata/connector/example/provider/cratedb/sql/CrateDbNotFilterProcessor.java
+++ b/src/main/java/com/zoomdata/connector/example/provider/cratedb/sql/CrateDbNotFilterProcessor.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.provider.cratedb.sql;
+
+import com.querydsl.core.types.Predicate;
+import com.zoomdata.connector.example.framework.common.sql.filter.FilterProcessor;
+import com.zoomdata.connector.example.framework.common.sql.filter.NotFilterProcessor;
+import com.zoomdata.gen.edc.filter.Filter;
+import com.zoomdata.gen.edc.filter.FilterFunction;
+import com.zoomdata.gen.edc.filter.FilterISNULL;
+import com.zoomdata.gen.edc.filter.FilterOR;
+import com.zoomdata.gen.edc.types.FieldType;
+
+public class CrateDbNotFilterProcessor extends NotFilterProcessor {
+
+    private FilterProcessor filtersProcessorRouter;
+
+    public CrateDbNotFilterProcessor(FilterProcessor filtersProcessorRouter) {
+        super(filtersProcessorRouter);
+        this.filtersProcessorRouter = filtersProcessorRouter;
+    }
+
+    /*  When negating most filters, CrateDB will include NULL values such that, we have 1,500 records
+     *  The column string_null has 15 values = 'Alaska', 453 nulls, and the rest other values. When we
+     *
+     *  select count(*) FROM myTable WHERE not string_field = 'Alaska'
+     *
+     *  CrateDB gives us 1,485, while Zoomdata expects 1,032, i.e., Zoomdata expects not to count the nulls. So
+     *  when we have a NOT filter we have to adjust the filter to look like
+     *
+     *  select count(*) FROM myTable WHERE not (string_field = 'Alaska' OR string_field is null)
+      * */
+    @Override
+    public Predicate processFilter(Filter filter) {
+        Filter filterForNot = filter.getFilterNOT().getFilter();
+        Filter adjustedFilter = filterForNot;
+        // Only apply to operators it could affect
+        if(filterHasAffectedClause(filterForNot)) {
+            // Type doesn't matter for a NULL filter, so use anything the filter processor will accept
+            Filter filterIsNull = new Filter().setType(FilterFunction.IS_NULL)
+                    .setFilterISNULL(new FilterISNULL().setPath(extractFilterPath(filterForNot)).setType(FieldType.STRING));
+
+            // Create an OR filter that takes the original condition and will also use IS NULL
+            FilterOR filterOr = new FilterOR();
+            filterOr.addToFilters(filterForNot);
+            filterOr.addToFilters(filterIsNull);
+            adjustedFilter = new Filter().setType(FilterFunction.OR).setFilterOR(filterOr);
+        }
+        return filtersProcessorRouter.processFilter(adjustedFilter).not();
+    }
+
+    private static boolean filterHasAffectedClause(Filter filter) {
+        return filter.isSetFilterEQ() || filter.isSetFilterEQI() || filter.isSetFilterGE() || filter.isSetFilterCONTAINS() ||
+                filter.isSetFilterENDS_WITH() || filter.isSetFilterGT() || filter.isSetFilterIN() || filter.isSetFilterLE() ||
+                filter.isSetFilterLT() || filter.isSetFilterSTARTS_WITH() || filter.isSetFilterTEXT_SEARCH();
+    }
+
+    private static String extractFilterPath(Filter filter) {
+        if(filter.isSetFilterEQ()) {
+            return filter.getFilterEQ().getPath();
+        } else if (filter.isSetFilterEQI()) {
+            return filter.getFilterEQI().getPath();
+        } else if (filter.isSetFilterCONTAINS()) {
+            return filter.getFilterCONTAINS().getPath();
+        } else if (filter.isSetFilterGE()) {
+            return filter.getFilterGE().getPath();
+        } else if (filter.isSetFilterGT()) {
+            return filter.getFilterGT().getPath();
+        } else if (filter.isSetFilterLE()) {
+            return filter.getFilterLE().getPath();
+        } else if (filter.isSetFilterLT()) {
+            return filter.getFilterLT().getPath();
+        } else if (filter.isSetFilterIN()) {
+            return filter.getFilterIN().getPath();
+        } else if (filter.isSetFilterSTARTS_WITH()) {
+            return filter.getFilterSTARTS_WITH().getPath();
+        } else if (filter.isSetFilterENDS_WITH()) {
+            return filter.getFilterENDS_WITH().getPath();
+        } else if (filter.isSetFilterTEXT_SEARCH()) {
+            return filter.getFilterTEXT_SEARCH().getPath();
+        }
+        throw new IllegalArgumentException("Invalid filter type for altering NOT clause");
+    }
+}

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # If timezone is not set to UTC, some time-based integration tests may fail
-java -Duser.timezone=UTC -jar target/connector-server-cratedb-1.1.1-exec.jar
+java -Duser.timezone=UTC -jar target/connector-server-cratedb-1.2.0-exec.jar


### PR DESCRIPTION
There are some significant changes here based on the updates to the core framework, including more modular support for filters and grouping, as well as various ports of minor bug fixes. Most dependent frameworks were also upgraded.

The copyright was also updated to reflect 2017, causing many files to be touched.

All integration tests pass after the updates on the 0.5.x Crate version. The core framework upgrades should allow a smoother transition to Crate 1.0 as we will be able to compartmentalize some of the PostgreSQL wire changes.