### PR TITLE
Dev/upgrade crate and driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ There's also a [tutorial video](https://drive.google.com/open?id=0B5hqni4_xCGadG
 
 _TODO: Link the Zoomdata connector testing guide when it's made publicly available_
 
-This package also includes a simple crate.io container pre-loaded with the Zoomdata connector testing reference data. It uses 
-[Docker](https://www.docker.com/) to run the container so no further installation is required.
+This package also includes a simple crate.io container pre-loaded with the Zoomdata connector testing reference data. It uses [Docker](https://www.docker.com/) to run the container so no further installation is required.
 
 First, build the container with:
 
@@ -53,7 +52,7 @@ First, build the container with:
 
 Run the container exposing the default ports. The ports can be adjusted if needed:
 
-`docker run -it --rm -p 4200:4200 -p 4300:4300 zoomdata/crate-test`
+`docker run -it --rm -p 4200:4200 -p 4300:4300 -p 5432:5432 zoomdata/crate-test`
 
 Assuming the default ports were used, you should now be able to see the two testing tables in the `integration_tests` schema via the web admin UI:
 
@@ -65,7 +64,7 @@ With our sample data source ready, [start the connector server](#starting) and l
 
 In connector shell, create a data source (assuming default ports):
 
-`datasource add -n cratedb CONNECTOR_TYPE CRATEDB JDBC_URL crate://localhost:4300`
+`datasource add -n cratedb CONNECTOR_TYPE CRATEDB JDBC_URL crate://localhost:5432`
 
 Run the structured query test suite to validate structured request and query functionality:
 
@@ -77,11 +76,12 @@ Run the meta test suite to validate server description and meta functionality:
 
 ## Limitations
 
-This connector has only been tested with the version 0.55.4 of crate.io. It's not guaranteed to work with any other versions.
+The connector uses the CrateDB JDBC driver 2.x, which means that it is compatible with CreateDB >= 0.57.0. The driver does not use the CrateDB transport port to connect to a CrateDB server any longer and the connection string format has changed since the driver version 1.x.
+
+Please see the [CrateDB JDBC documentation](https://crate.io/docs/reference/jdbc/en/2.1.2/#jdbc-driver-class) for further reference.
 
 ## Additional Notes
 
-Although this implementation uses Java and some freely available libraries for convenience, they are not a *requirement* for 
-building a connector server.
+Although this implementation uses Java and some freely available libraries for convenience, they are not a *requirement* for building a connector server.
 
 Any language capable of generating code from [Apache Thrift](https://thrift.apache.org/) can be used.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ With our sample data source ready, [start the connector server](#starting) and l
 
 In connector shell, create a data source (assuming default ports):
 
-`datasource add -n cratedb CONNECTOR_TYPE CRATEDB JDBC_URL crate://localhost:5432`
+`datasource add -n cratedb CONNECTOR_TYPE CRATEDB JDBC_URL crate://localhost:5432/`
 
 Run the structured query test suite to validate structured request and query functionality:
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <groupId>com.zoomdata</groupId>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>connector-server-cratedb</artifactId>
@@ -15,7 +15,7 @@
         <copyrightOwner>Zoomdata, Inc.</copyrightOwner>
         <!-- Versions -->
         <connector-api.version>2.3.1</connector-api.version>
-        <crate.jdbc.version>1.13.1</crate.jdbc.version>
+        <crate.jdbc.version>2.1.2</crate.jdbc.version>
         <query.dsl.version>4.1.4</query.dsl.version>
         <slf4j.version>1.7.22</slf4j.version>
         <logback.version>1.1.8</logback.version>

--- a/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBDataProvider.java
+++ b/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBDataProvider.java
@@ -29,7 +29,7 @@ public class CrateDBDataProvider extends GenericSQLDataProvider {
     // The unique connection type that will be registered in Zoomdata
     protected final static String CONNECTION_TYPE = "CRATEDB";
 
-    // This is how we'll assign special flats for Zoomdata such as PARTITION
+    // This is how we'll assign special flags for Zoomdata such as PARTITION
     private final CrateDBMetaFlagsDetector metaFlagsDetector;
 
     public CrateDBDataProvider() {

--- a/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBDataProvider.java
+++ b/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBDataProvider.java
@@ -4,10 +4,8 @@
 package com.zoomdata.connector.example.provider.cratedb;
 
 import com.google.common.collect.ImmutableSet;
-import com.zoomdata.connector.example.common.utils.FieldMetaFlag;
 import com.zoomdata.connector.example.framework.annotation.Connector;
 import com.zoomdata.connector.example.framework.api.IDescriptionProvider;
-import com.zoomdata.connector.example.framework.common.JdbcCommons;
 import com.zoomdata.connector.example.framework.common.sql.SQLQueryBuilder;
 import com.zoomdata.connector.example.framework.provider.GenericSQLDataProvider;
 import com.zoomdata.connector.example.framework.provider.serverdescription.GenericDescriptionProvider;
@@ -15,13 +13,12 @@ import com.zoomdata.connector.example.provider.cratedb.sql.CrateDBSQLQueryBuilde
 import com.zoomdata.gen.edc.request.MetaDescribeRequest;
 import com.zoomdata.gen.edc.types.FieldMetadata;
 
-import java.sql.*;
-import java.util.Arrays;
+import java.sql.Connection;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import static com.zoomdata.connector.example.common.utils.FieldMetaFlag.PLAYABLE;
 import static com.zoomdata.connector.example.framework.provider.serverdescription.connectionparameters.impl.PasswordConnectionParameter.PasswordConnectionParameterBuilder.passwordParameter;
 import static com.zoomdata.connector.example.framework.provider.serverdescription.connectionparameters.impl.StringConnectionParameter.StringConnectionParameterBuilder.stringParameter;
 import static com.zoomdata.connector.example.provider.cratedb.CrateDBDataProvider.CONNECTION_TYPE;
@@ -32,12 +29,16 @@ public class CrateDBDataProvider extends GenericSQLDataProvider {
     // The unique connection type that will be registered in Zoomdata
     protected final static String CONNECTION_TYPE = "CRATEDB";
 
+    // This is how we'll assign special flats for Zoomdata such as PARTITION
+    private final CrateDBMetaFlagsDetector metaFlagsDetector;
+
     public CrateDBDataProvider() {
         super(
             new CrateDBSQLTemplates(),
             new CrateDBTypesMapping(),
             new CrateDBFeatures()
         );
+        metaFlagsDetector = new CrateDBMetaFlagsDetector(sqlTemplates);
     }
 
     @Override
@@ -48,7 +49,7 @@ public class CrateDBDataProvider extends GenericSQLDataProvider {
     @Override
     protected Set<String> systemSchemas() {
         // A list of schemas used by the data source that we shouldn't display to end users
-        return ImmutableSet.of("sys", "information_schema", "blob");
+        return ImmutableSet.of("blob", "information_schema", "pg_catalog", "sys");
     }
 
     @Override
@@ -77,27 +78,7 @@ public class CrateDBDataProvider extends GenericSQLDataProvider {
     // fields that are partitions
     @Override
     protected void detectIndexedFields(Connection connection, MetaDescribeRequest request, List<FieldMetadata> metadata) throws SQLException {
-        String collectionName = request.getCollectionInfo().getCollection();
-        String schemaName = request.getCollectionInfo().getSchema();
-        String checkPartitions = String.format("SELECT partitioned_by FROM information_schema.tables WHERE lower(table_name)='%s'",
-            collectionName.toLowerCase());
-        if(schemaName != null) {
-            checkPartitions = checkPartitions.concat(String.format("AND lower(schema_name)='%s'", schemaName.toLowerCase()));
-        }
-        try (Statement statement = connection.createStatement(); ResultSet resultSet = statement.executeQuery(checkPartitions)) {
-            while(resultSet.next()) { // This should really only be once since we're filtering to table
-                Array result = resultSet.getArray(1);
-                if(result != null) {
-                    final Set<String> partitionedColumns = Arrays.stream((Object[]) result.getArray())
-                        .map(Object::toString)
-                        .collect(Collectors.toSet());
-                    metadata.stream()
-                        .filter(m -> partitionedColumns.contains(m.getName().toLowerCase()))
-                        .forEach(m -> FieldMetaFlag.addFlags(m, PLAYABLE));
-                }
-            }
-            JdbcCommons.closeResultSet(resultSet);
-        }
+        metaFlagsDetector.populateMetaFlags(connection, request.getCollectionInfo(), metadata);
     }
 
     @Override

--- a/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBMetaFlagsDetector.java
+++ b/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBMetaFlagsDetector.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) Zoomdata, Inc. 2012-2017. All rights reserved.
+ */
+package com.zoomdata.connector.example.provider.cratedb;
+
+import com.querydsl.sql.SQLTemplates;
+import com.zoomdata.gen.edc.request.CollectionInfo;
+import com.zoomdata.gen.edc.types.FieldMetadata;
+import lombok.extern.slf4j.Slf4j;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.function.Predicate;
+
+import static com.zoomdata.connector.example.common.utils.FieldMetaFlag.PLAYABLE;
+import static com.zoomdata.connector.example.common.utils.FieldMetaFlag.addFlags;
+import static com.zoomdata.connector.example.framework.common.PropertiesExtractor.tableName;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toSet;
+import static java.util.stream.Stream.of;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+import static org.apache.commons.lang3.StringUtils.left;
+import static org.apache.commons.lang3.StringUtils.substringBetween;
+
+@Slf4j
+public class CrateDBMetaFlagsDetector {
+
+    public static final String SHOW_CREATE_TABLE = "show create table ";
+
+    private final SQLTemplates sqlTemplates;
+
+    public CrateDBMetaFlagsDetector(SQLTemplates sqlTemplates) {
+        this.sqlTemplates = sqlTemplates;
+    }
+
+    public void populateMetaFlags(Connection connection, CollectionInfo collectionInfo, List<FieldMetadata> metadata) {
+        getCreateTableStatement(connection, collectionInfo)
+                .map(this::extractPartitionedFields)
+                .ifPresent(partitionedFields -> assignMetaFlagsToFields(metadata, partitionedFields));
+    }
+
+    private Optional<String> getCreateTableStatement(Connection connection, CollectionInfo collectionInfo) {
+        try (Statement ps = connection.createStatement();
+             ResultSet rs = ps.executeQuery(showStatement(collectionInfo))) {
+            return Optional.ofNullable(extractResultSet(rs));
+        } catch (SQLException e) {
+            log.warn("Failed to obtain CREATE TABLE statement for the schema [{}] and collection [{}]",
+                    collectionInfo.getSchema(), collectionInfo.getCollection(), e);
+            return Optional.empty();
+        }
+    }
+
+    private String showStatement(CollectionInfo collectionInfo) {
+        return SHOW_CREATE_TABLE + tableName(collectionInfo, sqlTemplates);
+    }
+
+    private String extractResultSet(ResultSet resultSet) throws SQLException {
+        StringJoiner joiner = new StringJoiner(" ");
+        while(resultSet.next()) {
+            joiner.add(resultSet.getString(1));
+        }
+        return joiner.toString();
+    }
+
+    /**
+     * Extracts names of partitioned fields from the PARTITIONED BY clause of a create statement. For example:
+     * <pre>
+     * PARTITIONED BY (
+     *      first_partition_key INT COMMENT 'The comment',
+     *      another_partition_key INT
+     * )
+     * </pre>
+     */
+    private Set<String> extractPartitionedFields(String createStatement) {
+        String partitionedByClause = ofNullable(substringBetween(createStatement, "PARTITIONED BY (", ")")).orElse(EMPTY);
+        return of(partitionedByClause.split(","))
+                .map(String::trim)
+                .map(this::extractColumnName)
+                .map(String::toLowerCase)
+                .collect(toSet());
+    }
+
+    private String extractColumnName(String columnDefinition) {
+        String quoteCharacter = getQuoteIdentifier();
+        return columnDefinition.split("\\s+")[0].replaceAll("^" + quoteCharacter + "|" + quoteCharacter + "$", "");
+    }
+
+    private String getQuoteIdentifier() {
+        // QueryDSL does not provide a simple way to get quote string so instead we'll put quotes around an identifier
+        String quoteIdentifier = left(sqlTemplates.quoteIdentifier(" "), 1);
+        return ofNullable(quoteIdentifier).orElse(EMPTY);
+    }
+
+    private void assignMetaFlagsToFields(List<FieldMetadata> metadata, Set<String> partitionedFields) {
+        Predicate<FieldMetadata> partitionedField = fieldMetadata -> partitionedFields.contains(fieldMetadata.getName().toLowerCase());
+        metadata.stream()
+                .filter(partitionedField)
+                .forEach(fieldMetadata -> addFlags(fieldMetadata, PLAYABLE));
+    }
+
+}

--- a/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBMetaFlagsDetector.java
+++ b/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBMetaFlagsDetector.java
@@ -82,7 +82,6 @@ public class CrateDBMetaFlagsDetector {
         return of(partitionedByClause.split(","))
                 .map(String::trim)
                 .map(this::extractColumnName)
-                .map(String::toLowerCase)
                 .collect(toSet());
     }
 

--- a/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBSQLTemplates.java
+++ b/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBSQLTemplates.java
@@ -5,7 +5,7 @@ package com.zoomdata.connector.example.provider.cratedb;
 
 import com.google.common.collect.ImmutableSet;
 import com.querydsl.core.types.Ops;
-import com.querydsl.sql.MySQLTemplates;
+import com.querydsl.sql.PostgreSQLTemplates;
 import com.zoomdata.connector.example.framework.common.sql.ops.ExtendedDateTimeOps;
 
 import java.sql.Types;
@@ -14,7 +14,7 @@ import java.text.SimpleDateFormat;
 import java.util.Set;
 
 // CrateDB mostly closely mimics MySQL dialect, so use the existing QueryDSL templates and modify as needed
-public class CrateDBSQLTemplates extends MySQLTemplates {
+public class CrateDBSQLTemplates extends PostgreSQLTemplates {
 
     private static final SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS");
 

--- a/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBTypesMapping.java
+++ b/src/main/java/com/zoomdata/connector/example/provider/cratedb/CrateDBTypesMapping.java
@@ -15,29 +15,26 @@ import java.util.Map;
 // From https://crate.io/docs/reference/sql/data_types.html
 public class CrateDBTypesMapping implements ITypesMapping {
 
-    private final Meta defaultMeta = metaString();
+    private final Meta defaultMeta = metaUnknown();
 
     private final Map<String, Meta> typesMapping =
         ImmutableMap.<String, Meta>builder()
+            // The types reported by the JDBC driver are PostgreSQL types and do not reflect https://crate.io/docs/reference/sql/data_types.html
             // Primitives
-            .put("boolean", metaString())
-            .put("byte", metaInt())
-            .put("short", metaInt())
-            .put("integer", metaInt())
-            .put("long", metaInt())
-            .put("float", metaDouble())
-            .put("double", metaDouble())
-            .put("string", metaString())
-            .put("ip", metaString())
-            .put("timestamp", metaTimestamp())
+            .put("bool", metaUnknown())
+            .put("char", metaString())
+            .put("float4", metaDouble())
+            .put("float8", metaDouble())
+            .put("int2", metaInt())
+            .put("int4", metaInt())
+            .put("int8", metaInt())
+            .put("varchar", metaString())
+            .put("timestamptz", metaTimestamp())
             // Geo types - Zoomdata generally doesn't handle native geo types for now
             // You can flatten geo types to a lat and long field and provide that way
-            .put("geo_point", metaUnknown())
-            .put("geo_shape", metaUnknown())
-            // Compound Types - Zoomdata typically needs nested or complex types to be flattened
-            // or specially handled
-            .put("object", metaUnknown())
-            .put("array", metaUnknown())
+            // Compound Types - Zoomdata typically needs nested or complex types to be flattened or specially handled
+            .put("float8_array", metaUnknown())
+            .put("json", metaUnknown())
             .build();
 
     private static Meta metaInt() {

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # If timezone is not set to UTC, some time-based integration tests may fail
-java -Duser.timezone=UTC -jar target/connector-server-cratedb-1.2.0-exec.jar
+java -Duser.timezone=UTC -jar target/connector-server-cratedb-1.3.0-exec.jar

--- a/test-server/Dockerfile
+++ b/test-server/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get -y install crate
 ADD crate-backup.tar.gz /var/lib/crate
 
 # Expose default Crate ports
-EXPOSE 4200 4300
+EXPOSE 4200 4300 5432
 
 RUN touch /var/log/crate/crate.log
 CMD service crate start && tail -F /var/log/crate/crate.log


### PR DESCRIPTION
There was an existing branch and PR for this, but to make the integration tests work, some more extensive work was needed even after the core framework was updated.

This Crate connector passes all integration tests and still connects to Zoomdata. Partitioned flags are treated as `PLAYABLE`.

Ruslan - your feedback is welcome if you have any. Thanks!